### PR TITLE
Update ksail formula for architecture-specific binaries

### DIFF
--- a/Formula/ksail.rb
+++ b/Formula/ksail.rb
@@ -1,8 +1,8 @@
 class Ksail < Formula
   desc "SDK for Kubernetes"
   homepage "https://github.com/devantler-tech/ksail"
-  license "MIT"
   sha256 "12a19ca431019f99596fbbb3b6e53197b9374efa9f886c09ca5493581cec8913"
+  license "MIT"
 
   if OS.mac?
     if Hardware::CPU.arm?

--- a/Formula/ksail.rb
+++ b/Formula/ksail.rb
@@ -1,9 +1,25 @@
 class Ksail < Formula
   desc "SDK for Kubernetes"
   homepage "https://github.com/devantler-tech/ksail"
-  url "https://github.com/devantler-tech/ksail/releases/download/v2.5.0/ksail.tar.gz"
-  sha256 "12a19ca431019f99596fbbb3b6e53197b9374efa9f886c09ca5493581cec8913"
   license "MIT"
+
+  if OS.mac?
+    if Hardware::CPU.arm?
+      url "https://github.com/devantler-tech/ksail/releases/download/v2.5.0/ksail-darwin-arm64"
+      sha256 "12a19ca431019f99596fbbb3b6e53197b9374efa9f886c09ca5493581cec8913"
+    elsif Hardware::CPU.intel?
+      url "https://github.com/devantler-tech/ksail/releases/download/v2.5.0/ksail-darwin-amd64"
+      sha256 "12a19ca431019f99596fbbb3b6e53197b9374efa9f886c09ca5493581cec8913"
+    end
+  elsif OS.linux?
+    if Hardware::CPU.arm?
+      url "https://github.com/devantler-tech/ksail/releases/download/v2.5.0/ksail-linux-arm64"
+      sha256 "12a19ca431019f99596fbbb3b6e53197b9374efa9f886c09ca5493581cec8913"
+    elsif Hardware::CPU.intel?
+      url "https://github.com/devantler-tech/ksail/releases/download/v2.5.0/ksail-linux-amd64"
+      sha256 "12a19ca431019f99596fbbb3b6e53197b9374efa9f886c09ca5493581cec8913"
+    end
+  end
 
   livecheck do
     url :stable
@@ -11,19 +27,7 @@ class Ksail < Formula
   end
 
   def install
-    if OS.mac?
-      if Hardware::CPU.arm?
-        bin.install "ksail-darwin-arm64" => "ksail"
-      elsif Hardware::CPU.intel?
-        bin.install "ksail-darwin-amd64" => "ksail"
-      end
-    elsif OS.linux?
-      if Hardware::CPU.arm?
-        bin.install "ksail-linux-arm64" => "ksail"
-      elsif Hardware::CPU.intel?
-        bin.install "ksail-linux-amd64" => "ksail"
-      end
-    end
+    bin.install "ksail-#{OS.kernel_name.downcase}-#{Hardware::CPU.arch}" => "ksail"
   end
 
   test do

--- a/Formula/ksail.rb
+++ b/Formula/ksail.rb
@@ -2,22 +2,19 @@ class Ksail < Formula
   desc "SDK for Kubernetes"
   homepage "https://github.com/devantler-tech/ksail"
   license "MIT"
+  sha256 "12a19ca431019f99596fbbb3b6e53197b9374efa9f886c09ca5493581cec8913"
 
   if OS.mac?
     if Hardware::CPU.arm?
       url "https://github.com/devantler-tech/ksail/releases/download/v2.5.0/ksail-darwin-arm64"
-      sha256 "12a19ca431019f99596fbbb3b6e53197b9374efa9f886c09ca5493581cec8913"
     elsif Hardware::CPU.intel?
       url "https://github.com/devantler-tech/ksail/releases/download/v2.5.0/ksail-darwin-amd64"
-      sha256 "12a19ca431019f99596fbbb3b6e53197b9374efa9f886c09ca5493581cec8913"
     end
   elsif OS.linux?
     if Hardware::CPU.arm?
       url "https://github.com/devantler-tech/ksail/releases/download/v2.5.0/ksail-linux-arm64"
-      sha256 "12a19ca431019f99596fbbb3b6e53197b9374efa9f886c09ca5493581cec8913"
     elsif Hardware::CPU.intel?
       url "https://github.com/devantler-tech/ksail/releases/download/v2.5.0/ksail-linux-amd64"
-      sha256 "12a19ca431019f99596fbbb3b6e53197b9374efa9f886c09ca5493581cec8913"
     end
   end
 


### PR DESCRIPTION
Enhance the ksail formula to support architecture-specific binaries for macOS and Linux, improving compatibility and installation experience.