### PR TITLE
fix: update ksail formula for specific macOS and Linux binaries

### DIFF
--- a/Formula/ksail.rb
+++ b/Formula/ksail.rb
@@ -11,20 +11,20 @@ class Ksail < Formula
 
   on_macos do
     if Hardware::CPU.intel?
-        url "https://github.com/devantler-tech/ksail/releases/download/v2.25.1/ksail-darwin-amd64"
-        sha256 "3af40b508d70813e461a2d8cfddbc11abc576643c775419c289669cd55394fec"
+      url "https://github.com/devantler-tech/ksail/releases/download/v2.25.1/ksail-darwin-amd64"
+      sha256 "3af40b508d70813e461a2d8cfddbc11abc576643c775419c289669cd55394fec"
 
-        def install
-          bin.install "ksail-darwin-amd64" => "ksail"
-        end
+      def install
+        bin.install "ksail-darwin-amd64" => "ksail"
+      end
     end
     if Hardware::CPU.arm?
-        url "https://github.com/devantler-tech/ksail/releases/download/v2.25.1/ksail-darwin-arm64"
-        sha256 "16c921b75f284012f9de64ba2df3d45a1c3f5829210ba601b0ce8ec7d6ad0485"
+      url "https://github.com/devantler-tech/ksail/releases/download/v2.25.1/ksail-darwin-arm64"
+      sha256 "16c921b75f284012f9de64ba2df3d45a1c3f5829210ba601b0ce8ec7d6ad0485"
 
-        def install
-          bin.install "ksail-darwin-arm64" => "ksail"
-        end
+      def install
+        bin.install "ksail-darwin-arm64" => "ksail"
+      end
     end
   end
   on_linux do

--- a/Formula/ksail.rb
+++ b/Formula/ksail.rb
@@ -1,8 +1,7 @@
 class Ksail < Formula
   desc "SDK for Kubernetes"
   homepage "https://github.com/devantler-tech/ksail"
-  url "https://github.com/devantler-tech/ksail/releases/download/v2.25.1/ksail.tar.gz"
-  sha256 "fdaff08b26a42ec565bd3866aab4067c9c9c193bce1ea1a4b7acf8300a4a8c46"
+
   license "Apache-2.0"
 
   livecheck do
@@ -10,18 +9,39 @@ class Ksail < Formula
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
-  def install
-    if OS.mac?
-      if Hardware::CPU.arm?
-        bin.install "ksail-darwin-arm64" => "ksail"
-      elsif Hardware::CPU.intel?
-        bin.install "ksail-darwin-amd64" => "ksail"
-      end
-    elsif OS.linux?
-      if Hardware::CPU.arm?
-        bin.install "ksail-linux-arm64" => "ksail"
-      elsif Hardware::CPU.intel?
+  on_macos do
+    if Hardware::CPU.intel?
+        url "https://github.com/devantler-tech/ksail/releases/download/v2.25.1/ksail-darwin-amd64"
+        sha256 "3af40b508d70813e461a2d8cfddbc11abc576643c775419c289669cd55394fec"
+
+        def install
+          bin.install "ksail-darwin-amd64" => "ksail"
+        end
+    end
+    if Hardware::CPU.arm?
+        url "https://github.com/devantler-tech/ksail/releases/download/v2.25.1/ksail-darwin-arm64"
+        sha256 "16c921b75f284012f9de64ba2df3d45a1c3f5829210ba601b0ce8ec7d6ad0485"
+
+        def install
+          bin.install "ksail-darwin-arm64" => "ksail"
+        end
+    end
+  end
+  on_linux do
+    if Hardware::CPU.intel?
+      url "https://github.com/devantler-tech/ksail/releases/download/v2.25.1/ksail-linux-amd64"
+      sha256 "6eff03768f5faaa9357c1184436be8f5c2c8066740c701a5b3d643b3b3cfb60d"
+
+      def install
         bin.install "ksail-linux-amd64" => "ksail"
+      end
+    end
+    if Hardware::CPU.arm?
+      url "https://github.com/devantler-tech/ksail/releases/download/v2.25.1/ksail-linux-arm64"
+      sha256 "facf32da03be935b89d86a17dfda973c4810fb080cb884c0601cbe6e40e66382"
+
+      def install
+        bin.install "ksail-linux-arm64" => "ksail"
       end
     end
   end


### PR DESCRIPTION
Update the ksail formula to use specific URLs for macOS and Linux binaries, ensuring proper installation based on the CPU architecture.