### PR TITLE
Potential fix for code scanning alert no. 16: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/todos.yaml
+++ b/.github/workflows/todos.yaml
@@ -1,4 +1,6 @@
 name: "TODOs"
+permissions:
+  contents: read
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/todos.yaml
+++ b/.github/workflows/todos.yaml
@@ -1,6 +1,5 @@
 name: "TODOs"
-permissions:
-  contents: read
+permissions: {}
 on:
   workflow_dispatch:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/devantler-tech/homebrew-formulas/security/code-scanning/16](https://github.com/devantler-tech/homebrew-formulas/security/code-scanning/16)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will define the minimal permissions required for the workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
