### PR TITLE
chore: pin actions to v2.1.0 SHA

### DIFF
--- a/.github/workflows/sync-labels.yaml
+++ b/.github/workflows/sync-labels.yaml
@@ -21,4 +21,4 @@ jobs:
         with:
           persist-credentials: false
       - name: 🔄 Sync labels
-        uses: devantler-tech/actions/sync-labels-action@884a9b7321e269351d5fc006d95e0b50b2ddedf6 # v1.9.7
+        uses: devantler-tech/actions/sync-github-labels@4235593b654b467bb57c2d2f492b1461eab37cba # v2.1.0

--- a/.github/workflows/todos.yaml
+++ b/.github/workflows/todos.yaml
@@ -8,6 +8,6 @@ on:
 
 jobs:
   todos:
-    uses: devantler-tech/reusable-workflows/.github/workflows/scan-for-todo-comments.yaml@a7c930391dcd50fcb1721153c5fb08f7dbfc9ee8 # v2.0.0
+    uses: devantler-tech/reusable-workflows/.github/workflows/scan-for-todo-comments.yaml@9ec9792d6c140612f6b5bafa5dc786e751b5ff1a # v2.2.0
     secrets:
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}


### PR DESCRIPTION
Pin all `devantler-tech/actions` workflow callsites to the latest semver release SHA:
`4235593b654b467bb57c2d2f492b1461eab37cba` (`v2.1.0`).

Fixes N/A

## Type of change

EOF- [ ] - [ ] - [ ] - [ ] - [x] 