### PR TITLE
ci: gate PRs on brew audit --strict --online for every Cask

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,12 +8,49 @@ on:
 permissions: {}
 
 jobs:
+  audit-casks:
+    name: 🔍 Audit Casks
+    # macOS has Homebrew preinstalled; Casks run on macOS so audit them there.
+    runs-on: macos-latest
+    permissions:
+      contents: read # checkout
+    steps:
+      - name: 🔒 Harden runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit # brew audit --online fetches the release assets
+      - name: 📥 Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false # read-only job; never pushes
+      - name: 🔍 brew audit --strict --online (every Cask)
+        # `brew audit` only accepts a Cask *name* (the path form is disabled), so
+        # expose this checkout to Homebrew as the real tap via a symlink, then
+        # audit each Cask by `<tap>/<name>`. `--online` resolves url + sha256 and
+        # the verified-domain rule; `--strict` turns style/quality warnings into
+        # failures. Auditing every Cask means adding a third "just works".
+        run: |
+          set -euo pipefail
+          tap_dir="$(brew --repository)/Library/Taps/devantler-tech/homebrew-tap"
+          mkdir -p "$(dirname "$tap_dir")"
+          ln -sfn "$GITHUB_WORKSPACE" "$tap_dir"
+          status=0
+          for cask in Casks/*.rb; do
+            name="$(basename "$cask" .rb)"
+            echo "::group::brew audit $name"
+            brew audit --strict --online --cask "devantler-tech/tap/$name" || status=1
+            echo "::endgroup::"
+          done
+          exit "$status"
+
   required-checks:
     name: CI - Required Checks
     if: always()
     runs-on: ubuntu-latest
+    needs: [audit-casks]
+    permissions: {}
     steps:
       - name: ✅ Aggregate job checks
         uses: devantler-tech/actions/aggregate-job-checks@6916c45ed8dc22e62cb12f021480e29732d03575 # v5.1.0
         with:
-          job-results: ""
+          job-results: ${{ needs.audit-casks.result }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@
 - `Casks/ksail.rb` — Cask for the `ksail` CLI binary (macOS arm64, Linux amd64/arm64). GoReleaser-generated (`# DO NOT EDIT`).
 - `Casks/ksail-desktop.rb` — Cask for the `KSail.app` desktop app (macOS arm64). GoReleaser-generated (`# DO NOT EDIT`).
 - `README.md` — tap landing page: a Formula/Description table and install instructions.
-- `.github/workflows/ci.yaml` — required-checks aggregator run on `pull_request` and `merge_group` (`devantler-tech/actions/aggregate-job-checks`).
+- `.github/workflows/ci.yaml` — runs `brew audit --strict --online` on every Cask (macOS) and aggregates the result into the required-checks gate (`devantler-tech/actions/aggregate-job-checks`) on `pull_request` and `merge_group`.
 - `.github/workflows/sync-labels.yaml` — weekly + on-demand GitHub label sync.
 - `.github/workflows/todos.yaml` — scans pushed-to-`main` commits for TODO comments and files issues.
 - `.github/dependabot.yaml` — daily `github-actions` dependency updates.
@@ -18,7 +18,7 @@ Each Cask carries `version`, per-platform `sha256` + `url` pointing at the corre
 
 ## Validation
 
-CI here runs only the aggregate required-checks job — it does **not** run `brew style`/`brew audit`. So validate locally before any PR:
+CI runs `brew audit --strict --online` on every Cask and blocks merge on failure. It does **not** yet run `brew style` — the GoReleaser-generated Casks (`# DO NOT EDIT`) currently trip ~20 RuboCop style offenses (stanza order, `depends_on :macos`, modifier-`if`, blank lines) that can only be fixed in the upstream GoReleaser cask template, so a style gate would block every PR until that lands. Until then, still validate `brew style` locally:
 
 - If `brew` is available: `brew style ./Casks/<cask>.rb` and `brew audit --strict --online --cask <cask>`.
 - Otherwise: `ruby -c Casks/<cask>.rb` for a syntax check, plus a careful manual read.
@@ -31,7 +31,7 @@ These conventions guide the autonomous **Daily AI Assistant** — and any agenti
 
 **Releases bump Casks automatically.** A tool release (e.g. ksail) opens its own PR to update a Cask's `url`/`version`/`sha256`. **Do NOT hand-edit version/sha to chase a release** — you'd race the automation and risk a wrong sha. Your job is Cask *correctness/hygiene*, not version bumps.
 
-**Recommended local validation before any PR:** CI here runs only the aggregate required-checks job and does **not** run `brew style`/`brew audit`, so validate locally first — `brew style ./Casks/<cask>.rb` and `brew audit --strict --online --cask <cask>` if `brew` is available; else `ruby -c Casks/<cask>.rb` + a careful read.
+**Recommended local validation before any PR:** CI runs `brew audit --strict --online` (and blocks on it) but not `brew style` yet, so still validate `brew style` locally first — `brew style ./Casks/<cask>.rb` and `brew audit --strict --online --cask <cask>` if `brew` is available; else `ruby -c Casks/<cask>.rb` + a careful read.
 
 **Task menu** (minimal; usually nothing to do):
 - **Triage** new issues/PRs; one insightful comment on the oldest un-commented item (e.g. an install-failure report → investigate the Cask).


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

Addresses the **audit half** of #734 (epic #732). Splits off `brew style` as blocked-on-upstream (see below).

## Problem

CI here ran only the `CI - Required Checks` aggregator — it did **not** run `brew audit`. A malformed Cask (dead `url`, wrong `sha256`, missing/wrong `desc`/`homepage`/`license`, an unverified cross-domain `url`) could land on `main` undetected. This was not hypothetical: the `desc ""`/`homepage ""` regression and the missing `verified:` cross-domain failure both shipped to `main` before being caught locally on a later tick.

## What this does

Adds an `audit-casks` job that:

1. Runs on `macos-latest` (Homebrew preinstalled; Casks run on macOS).
2. Exposes the checkout to Homebrew as the real tap via a `Library/Taps` symlink — `brew audit` no longer accepts a path (`Calling brew audit [path ...] is disabled`), only a Cask **name**, so each Cask is audited as `devantler-tech/tap/<name>`.
3. Runs `brew audit --strict --online --cask <name>` for **every** file in `Casks/` (auto-iterates, so a third Cask "just works"). `--online` resolves `url`+`sha256` and the verified-domain rule; `--strict` promotes quality warnings to failures.
4. Feeds its result into the existing `CI - Required Checks` aggregator (`needs: [audit-casks]` + `job-results: ${{ needs.audit-casks.result }}`), so it gates both `pull_request` and `merge_group` with **no ruleset change** needed.

Hash-pinned actions + `harden-runner` (egress `audit`, since `--online` fetches release assets) + `persist-credentials: false`, matching the portfolio pattern.

## Validation (local, brew 5.1.14, macOS)

- Both currently-shipped Casks **pass** `brew audit --strict --online` today — verified against a fresh `brew tap` clone of `main` (v7.23.4), cache cleared: `ksail` exit 0, `ksail-desktop` exit 0. The `verified:` fix from the recent ksail GoReleaser change (the cross-domain `github.com` vs `ksail.devantler.tech` rule) is what makes them pass — this is exactly acceptance criterion #3 ("all currently-shipped Casks pass after the upstream template fix lands"), now satisfied.
- A deliberately-broken trial Cask (homepage with a differing domain and no `verified:`) **fails** the job with `exit 1` — the gate blocks as intended (acceptance criterion #2).
- `actionlint` clean (incl. embedded shellcheck on the `run:` script).

## Why audit-only — `brew style` is deferred (split from #734)

`brew style` currently reports **20 offenses** (19 autocorrectable) across both Casks, e.g. `Cask/StanzaOrder`, `Homebrew/OSDependsOn` (`depends_on :macos`), `Style/IfUnlessModifier`, `Layout/EmptyLinesAroundBlockBody`, `Layout/ArgumentAlignment`, plus `Cask/Desc` (desc starts with the cask name) and `Cask/HomepageUrlStyling` (missing slash after domain). The Casks are **GoReleaser-generated and marked `# DO NOT EDIT`**, so `brew style --fix` output cannot be committed — the next release would regenerate it. Most offenses are template-structure controlled by GoReleaser's cask template (not configurable per-cask), so a `brew style` gate would block **every** PR until the upstream GoReleaser template is fixed in `devantler-tech/ksail`.

→ Recommend keeping #734 open for the `brew style` half (blocked on an upstream ksail GoReleaser-template change), or splitting it into its own issue. This PR delivers the higher-value, immediately-green audit gate now.

## Trade-offs / notes

- The job uses a `Library/Taps` symlink so `brew audit` can address Casks by name; this is the standard third-party-tap CI approach and keeps the audit pointed at the PR's content (not the published tap).
- `merge_group` is included so the gate also runs in the merge queue, not just on PR checks.

Draft for the maintainer to promote. Once promoted with `CI - Required Checks` green and threads resolved, I'll drive it to merge.