### PR TITLE
docs(readme): correct tap landing to Casks + list ksail-desktop

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@
 
 - `Casks/ksail.rb` — Cask for the `ksail` CLI binary (macOS arm64, Linux amd64/arm64). GoReleaser-generated (`# DO NOT EDIT`).
 - `Casks/ksail-desktop.rb` — Cask for the `KSail.app` desktop app (macOS arm64). GoReleaser-generated (`# DO NOT EDIT`).
-- `README.md` — tap landing page: a Formula/Description table and install instructions.
+- `README.md` — tap landing page: a Cask/Description table and install instructions.
 - `.github/workflows/ci.yaml` — required-checks aggregator run on `pull_request` and `merge_group` (`devantler-tech/actions/aggregate-job-checks`).
 - `.github/workflows/sync-labels.yaml` — weekly + on-demand GitHub label sync.
 - `.github/workflows/todos.yaml` — scans pushed-to-`main` commits for TODO comments and files issues.

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ The [Homebrew](https://brew.sh) tap for [devantler-tech](https://github.com/deva
 
 | Cask | Description |
 | ---- | ----------- |
-| [ksail](https://github.com/devantler-tech/ksail) | CLI tool to manage Kubernetes clusters and workloads. |
-| [ksail-desktop](https://github.com/devantler-tech/ksail) | Desktop app to manage local Kubernetes clusters in a native window. |
+| [ksail](https://github.com/devantler-tech/ksail) | KSail is a CLI tool to manage clusters and workloads. |
+| [ksail-desktop](https://github.com/devantler-tech/ksail) | KSail desktop app — manage local Kubernetes clusters in a native window. |
 
 ## How do I install these Casks?
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ The [Homebrew](https://brew.sh) tap for [devantler-tech](https://github.com/deva
 | Cask | Description |
 | ---- | ----------- |
 | [ksail](https://github.com/devantler-tech/ksail) | KSail is a CLI tool to manage clusters and workloads. |
-| [ksail-desktop](https://github.com/devantler-tech/ksail) | KSail desktop app — manage local Kubernetes clusters in a native window. |
+| [ksail-desktop](https://github.com/devantler-tech/ksail) | KSail desktop app — manage local Kubernetes clusters in a native window |
 
 ## How do I install these Casks?
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
-# DevantlerTech Formulas
+# devantler-tech Homebrew tap
 
-| Formula | Description |
-| ------- | ----------- |
-| [ksail](https://github.com/devantler-tech/ksail)   | An SDK for Kubernetes. |
+The [Homebrew](https://brew.sh) tap for [devantler-tech](https://github.com/devantler-tech) tools. It distributes **Casks** — install them with `brew install --cask`.
 
+| Cask | Description |
+| ---- | ----------- |
+| [ksail](https://github.com/devantler-tech/ksail) | CLI tool to manage Kubernetes clusters and workloads. |
+| [ksail-desktop](https://github.com/devantler-tech/ksail) | Desktop app to manage local Kubernetes clusters in a native window. |
 
 ## How do I install these Casks?
 
@@ -14,3 +16,7 @@ Or `brew tap devantler-tech/tap` and then `brew install --cask <cask>`.
 ## Documentation
 
 `brew help`, `man brew` or check [Homebrew's documentation](https://docs.brew.sh).
+
+## Maintenance
+
+Repository conventions for maintainers and agentic tools live in [`AGENTS.md`](AGENTS.md).


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

Fixes #733. Part of epic #732 (polished, lint-clean Homebrew tap).

## Problem

`README.md` is the tap's user-facing landing page, and it contradicted reality:

1. **Title** said `# DevantlerTech Formulas`, but the tap distributes **Casks**, not formulas — `AGENTS.md` calls this out explicitly.
2. The table was headed `| Formula | … |` and listed **only `ksail`**, omitting the `ksail-desktop` Cask we already ship (`Casks/ksail-desktop.rb`).
3. The install snippet below correctly says `brew install --cask …`, so the page said "Formula" then "Cask" in adjacent sentences.

A user landing here for "ksail desktop install" never saw the desktop app was available.

## Change (two files — `README.md` + `AGENTS.md`)

**`README.md`:**
- Retitled to **`devantler-tech Homebrew tap`** — accurate, short.
- Column header `Formula` → **`Cask`**.
- Listed **both** Casks with one-line descriptions reproduced from each Cask's own `desc` (periods normalised for the table):
  - `ksail` — `KSail is a CLI tool to manage clusters and workloads.`
  - `ksail-desktop` — `KSail desktop app — manage local Kubernetes clusters in a native window.`
- Kept the working install snippet (`brew install --cask devantler-tech/tap/<cask>`); both table names match it.
- Added a discoverable pointer to `AGENTS.md` for contributors/agents (the optional item in the issue).

**`AGENTS.md`:**
- Updated the Structure section so it describes the README table as `Cask | Description` rather than the old `Formula | Description`, keeping the contributor docs in sync with the landing page.

## Acceptance criteria

- [x] Title reflects that the repo is a Homebrew tap, not a Formulas repo.
- [x] Casks table lists both `ksail` and `ksail-desktop` with one-line descriptions matching their Cask `desc`.
- [x] Column header reads `Cask`, not `Formula`.
- [x] Install snippet still works.
- [x] No change to `Casks/*.rb` (they are `# DO NOT EDIT`).

## Validation

Docs-only change; no `Casks/*.rb` or workflow touched. CI here runs only the aggregate required-checks job (it doesn't run `brew style`/`brew audit`), and there is no `brew`/Cask behaviour change to audit. Markdown table verified to render with both rows; one-liners verified against the live `desc` strings in `Casks/ksail.rb` and `Casks/ksail-desktop.rb`.

---

Note for the maintainer (not in this PR): sibling issue #736 proposes adding an Apache-2.0 `LICENSE` "to align with the rest of the public portfolio" — but **no** other public devantler-tech repo currently carries a LICENSE (ksail/platform/templates/actions/… all show `license=none`), so adding one only here would make the tap the outlier, not aligned. Licensing is a maintainer policy call; flagging rather than acting on that part of #736. The empty repo **description** (also in #736) is a valid, consistent gap — every other repo has one — but it's a repo-settings change, not a diff.
