### PR TITLE
ci: authenticate brew audit GitHub API calls to fix flaky rate-limit failures

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,6 +29,13 @@ jobs:
         # audit each Cask by `<tap>/<name>`. `--online` resolves url + sha256 and
         # the verified-domain rule; `--strict` turns style/quality warnings into
         # failures. Auditing every Cask means adding a third "just works".
+        env:
+          # `--online` hits the GitHub API to resolve release assets; without a
+          # token brew uses the unauthenticated limit (60/hr per runner IP, shared
+          # across all Actions runners on that IP) and intermittently fails with
+          # "API rate limit exceeded", flakily blocking every PR. The job token
+          # raises this to 5,000/hr. Read-only; matches the `contents: read` scope.
+          HOMEBREW_GITHUB_API_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           tap_dir="$(brew --repository)/Library/Taps/devantler-tech/homebrew-tap"


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Problem

The `🔍 Audit Casks` job added in #756 — now a **required** check on every PR (`needs: [audit-casks]` feeds `CI - Required Checks`) — runs `brew audit --strict --online`. The `--online` flag resolves each Cask's release assets via the **GitHub API**. With no token, Homebrew falls back to the *unauthenticated* limit (**60 requests/hr, shared per runner IP** across all GitHub-hosted Actions runners on that IP), so the audit intermittently aborts with:

```
exception while auditing ksail: GitHub API Error: API rate limit exceeded for 13.105.117.201.
```

This is environmental, not a Cask defect — and because the job gates `CI - Required Checks`, the flaky failure **blocks every PR in the repo** when the shared IP's unauthenticated budget is exhausted. Observed live on #757 (audit failed purely on the rate-limit exception; the Casks themselves are audit-clean).

## Change

Add `HOMEBREW_GITHUB_API_TOKEN: ${{ github.token }}` to the audit step's `env`. Homebrew uses it for its GitHub API calls, raising the limit to the **authenticated 5,000/hr** and eliminating the flake. The token is the job's own read-only `GITHUB_TOKEN` (the job already declares `contents: read`); for fork PRs it is read-only by default, so this adds no privilege. `harden-runner` stays `egress-policy: audit`, so the authenticated `api.github.com` call is unaffected.

## Validation

- `actionlint .github/workflows/ci.yaml` — clean.
- Same-repo PRs run the workflow from the PR branch, so this PR's own `🔍 Audit Casks` run exercises the authenticated path — it should now pass without the rate-limit exception.

## Follow-up

Once this lands, #757 (README→Casks landing) just needs its merge re-run to pick up the reliable gate.
