### PR TITLE
ci: self-test that the Cask audit gate rejects broken Casks

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,6 +23,32 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false # read-only job; never pushes
+      - name: 🧪 Self-test — the gate must reject a broken Cask
+        # Regression guard: prove the audit gate actually blocks, not just that it
+        # runs. Build a deliberately-broken Cask in a throwaway tap and assert
+        # `brew audit` rejects it; if it ever PASSES, the gate has silently stopped
+        # enforcing and we fail the job. Offline (no `--online`) so it is
+        # deterministic and needs no network or token — the broken Cask trips
+        # offline-detectable rules (missing homepage/desc/artifact, bad sha256).
+        run: |
+          set -euo pipefail
+          selftap="$(brew --repository)/Library/Taps/devantler-tech-selftest/homebrew-selftest"
+          mkdir -p "$selftap/Casks"
+          cleanup() { rm -rf "$selftap"; }
+          trap cleanup EXIT
+          cat > "$selftap/Casks/broken-selftest.rb" <<'RUBY'
+          cask "broken-selftest" do
+            version "0.0.0"
+            sha256 "deadbeef"
+            url "https://example.invalid/broken-selftest/nope.zip"
+            name "broken selftest"
+          end
+          RUBY
+          if brew audit --strict --cask "devantler-tech-selftest/selftest/broken-selftest"; then
+            echo "::error::Self-test failed: a deliberately-broken Cask passed audit — the gate is not enforcing."
+            exit 1
+          fi
+          echo "Self-test OK: the broken Cask was correctly rejected by brew audit."
       - name: 🔍 brew audit --strict --online (every Cask)
         # `brew audit` only accepts a Cask *name* (the path form is disabled), so
         # expose this checkout to Homebrew as the real tap via a symlink, then


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

Partially addresses #734 (epic #732). Delivers the *"a deliberately-broken Cask must fail the job and block merge"* acceptance criterion.

## What

The `audit-casks` job already runs `brew audit --strict --online` on every Cask, but nothing proved the gate actually **blocks** — only that it runs. A regression in the loop's `|| status=1` / `exit "$status"` wiring (or an upstream `brew` change) could silently let a broken Cask through while CI still reported green.

This adds a self-test step that:
1. Writes a deliberately-broken Cask into a throwaway tap (`devantler-tech-selftest/homebrew-selftest`), isolated from the real `Casks/`.
2. Asserts `brew audit --strict` **rejects** it; if it ever passes, the gate has stopped enforcing → the job fails.
3. Cleans up via `trap … EXIT`.

Runs **offline** (no `--online`) so it is deterministic and needs no network or token — the broken Cask trips offline-detectable rules (missing `homepage`/`desc`/artifact, bad `sha256`).

## Validation

Ran the exact extracted step script locally against Homebrew 5.1.15:

```
Error: 6 problems in 1 cask detected.   # brew correctly rejects the broken Cask
…
Self-test OK: the broken Cask was correctly rejected by brew audit.
=== self-test step exit: 0 ===          # gate enforces → job proceeds
```

## On the rest of #734 (`brew style`) — needs a decision

While here I checked the `brew style` half of #734 against the live Casks. **Both shipped Casks are GoReleaser-generated** (`# This file was generated by GoReleaser. DO NOT EDIT.`), and `brew style` reports **17 offenses** (12 in `ksail-desktop.rb`, 5 in `ksail.rb`) — `Cask/StanzaOrder`, `Layout/ArgumentAlignment`, `Style/FrozenStringLiteralComment`, `Cask/HomepageUrlStyling`, `Style/IfUnlessModifier`, `Layout/EmptyLinesAroundBlockBody`. Almost all are emitted by **GoReleaser's own cask template**, so they can't be hand-fixed here (generated files) and mostly aren't controllable from ksail's `.goreleaser.yaml` either.

`brew audit --strict --online` (already shipped) is what enforces #734's stated goal — *"so broken Casks can't land"* — by catching the correctness issues (bad url/sha256/desc/homepage/license/verified-domain). `brew style` only adds cosmetic RuboCop formatting on generator output. Recommendation in the issue thread: **descope `brew style` from #734** (or split it into a separate, lower-priority item pursued via a post-release `brew style --fix` autocorrect), and close #734 once this self-test lands. See the issue comment for the full evidence + options.

## Why draft

Per the contract, code/CI PRs open as drafts; promote to ready when you're happy with the direction.