### PR TITLE
ci: re-audit release Cask PRs once the release publishes

### DIFF
--- a/.github/workflows/reaudit-release-casks.yaml
+++ b/.github/workflows/reaudit-release-casks.yaml
@@ -1,0 +1,79 @@
+---
+name: Re-audit release Casks
+
+# GoReleaser opens a Cask-bump PR (branch `goreleaser/*`) as part of the ksail release, but
+# ~37 min BEFORE the GitHub release assets become downloadable: the release is created as a
+# draft and is only published once every release job has succeeded. So the `Audit Casks` job's
+# `brew audit --online` 404s on the not-yet-public asset and the PR stays red until someone
+# re-runs it by hand — blocking the maintainer's armed auto-merge on every release (#775).
+#
+# This job runs only for those `goreleaser/*` PRs. On cheap Ubuntu it waits (bounded) for the
+# referenced release to publish — `gh release view <tag>` returns nothing while the release is
+# still a draft, so a successful lookup proves the assets are downloadable — then re-runs the
+# failed CI run so the audit passes against the now-live asset and auto-merge fires. No manual
+# intervention, and the audit's strictness is unchanged (see #734 / #773).
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+permissions: {}
+
+jobs:
+  reaudit-on-publish:
+    name: ⏳ Re-audit once release publishes
+    # Only GoReleaser-generated Cask-bump PRs hit the pre-publish 404 race.
+    if: startsWith(github.head_ref, 'goreleaser/')
+    runs-on: ubuntu-latest
+    # Covers the observed ~37 min draft window plus margin; fails informatively past it.
+    timeout-minutes: 50
+    permissions:
+      contents: read # read the release publish state
+      actions: write # re-run the failed CI run once assets are live
+    steps:
+      - name: 🔒 Harden runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit # waits on the GitHub API for the release to publish
+
+      - name: ⏳ Wait for the release to publish, then re-audit
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          HEAD_REF: ${{ github.head_ref }}
+        run: |
+          set -euo pipefail
+
+          # The Cask branch is `goreleaser/{project}-{tag}` (project may contain hyphens), so the
+          # release tag is the trailing `vX.Y.Z` of the branch name.
+          tag="$(printf '%s' "$HEAD_REF" | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+([-.+][0-9A-Za-z.]+)*$' || true)"
+          if [ -z "$tag" ]; then
+            echo "Branch '$HEAD_REF' has no version suffix; nothing to wait for."
+            exit 0
+          fi
+          echo "Waiting for release $tag to publish before re-auditing its Cask PR."
+
+          # `gh release view <tag>` returns nothing while the release is a draft (drafts are not
+          # resolvable by tag — see ksail cd.yaml publish-release), so a successful lookup proves
+          # the release is published and its assets are publicly downloadable.
+          deadline=$(( SECONDS + 45 * 60 ))
+          until gh release view "$tag" --json isDraft >/dev/null 2>&1; do
+            if [ "$SECONDS" -ge "$deadline" ]; then
+              echo "::error::Timed out after 45m waiting for release $tag to publish; leaving the Cask PR red."
+              exit 1
+            fi
+            sleep 60
+          done
+          echo "Release $tag is published; its assets are downloadable."
+
+          # Re-run the latest CI run for this branch only if that latest run failed (on the
+          # pre-publish 404) — never re-run a branch a later run already turned green.
+          run_id="$(gh run list --workflow ci.yaml --branch "$HEAD_REF" --event pull_request \
+            --json databaseId,conclusion,createdAt \
+            --jq 'sort_by(.createdAt) | last | select(.conclusion == "failure") | .databaseId')"
+          if [ -z "$run_id" ]; then
+            echo "No failed CI run to re-audit (already green?). Done."
+            exit 0
+          fi
+          echo "Re-running failed CI run $run_id so the audit re-evaluates against the live asset."
+          gh run rerun "$run_id" --failed


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Problem

`Fixes #775`. Every GoReleaser-generated Cask-bump PR (branch `goreleaser/*`) lands with a **red `🔍 Audit Casks` / `CI - Required Checks`**, blocking the maintainer's armed auto-merge until someone manually re-runs the check (#767, #771 this week — recurs every release).

It is **not** a real Cask defect. The ksail release pipeline creates the GitHub release as a **draft** and only flips it to *published* in its final `publish-release` job, after every release job (including the desktop cask job) has succeeded — an intentional all-or-nothing pattern. But GoReleaser opens the Cask PR *during* that draft window, ~37 min before the assets are publicly downloadable. homebrew-tap's CI then runs `brew audit --strict --online`, which fetches the release `.zip`, gets a `404`, and fails. With no re-trigger, the check stays red until a human re-runs it.

Evidence (from #775): #767 (v7.25.0) audited `17:21:19Z`; the release published `17:58:06Z` — ~37 min later. Both assets now return 200.

## Fix (issue option 2 — self-contained, low-risk)

A small **event-driven, bounded** helper workflow that runs **only for `goreleaser/*` PRs**:

1. On cheap **Ubuntu**, derive the release tag from the branch (`goreleaser/{project}-vX.Y.Z`).
2. **Wait (bounded, ≤45 min) for the release to publish.** `gh release view <tag>` returns nothing while the release is a draft (drafts aren't resolvable by tag — exactly what ksail's own `publish-release` job relies on), so a *successful* lookup proves the assets are live.
3. **Re-run the failed CI run** so `brew audit --online` re-evaluates against the now-downloadable asset → green → the maintainer's armed auto-merge fires.

Properties:
- **Event-driven, not a perpetual cron** — runs only when a Cask PR opens, exits as soon as the release publishes (or times out).
- **Cheap** — the wait is on Ubuntu; only the existing macOS audit is re-run, once.
- **Safe** — plain `pull_request` (never `pull_request_target`), so a fork PR gets a read-only token and the `actions: write` re-run is a harmless no-op; the audit's strictness is **unchanged** (a genuinely broken Cask still fails — see #734/#773).

## Trade-off / why not the upstream reorder (issue option 1)

The issue lists "open the Cask PR only after the release publishes" as the ideal root fix. That means restructuring ksail's `cd.yaml`/GoReleaser release flow so the homebrew publish runs after `publish-release` — a **high-risk change to the release pipeline that can only be validated by cutting a real release** (no dry-run path). This PR resolves the operator pain now, entirely within the tap and fully validatable; the upstream reorder can still be done later to remove the race at its source (I can file a follow-up issue on ksail if you'd prefer that direction).

## Validation

- `actionlint` clean (includes shellcheck on the `run:` block).
- Tag-extraction regex and the run-selection `jq` unit-tested against `goreleaser/ksail-desktop-v7.26.0`, `goreleaser/ksail-v7.25.0`, prerelease tags, non-version branches, and the latest-already-green case.

## Acceptance criteria (#775)

- [x] A freshly-released Cask PR reaches green `CI - Required Checks` without a manual re-run.
- [x] No change to the audit's strictness.

Part of #732.