### PR TITLE
test(ci): regression-test the Cask-bump supersession predicate

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -87,14 +87,34 @@ jobs:
           done
           exit "$status"
 
+  test-scripts:
+    name: 🧪 Test scripts
+    # Hermetic (no network, no Homebrew) regression test for the version-comparison predicate behind
+    # close-superseded-cask-bumps.yaml's destructive close/keep decision. Runs on Linux on every PR so
+    # a change to scripts/is-superseded.sh is gated here — that workflow only runs on push/schedule.
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # checkout
+    steps:
+      - name: 🔒 Harden runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit # the test needs no network; audit matches the repo's other jobs
+      - name: 📥 Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false # read-only job; never pushes
+      - name: 🧪 Run script tests
+        run: bash test/is-superseded.test.sh
+
   required-checks:
     name: CI - Required Checks
     if: always()
     runs-on: ubuntu-latest
-    needs: [audit-casks]
+    needs: [audit-casks, test-scripts]
     permissions: {}
     steps:
       - name: ✅ Aggregate job checks
         uses: devantler-tech/actions/aggregate-job-checks@9d98cb8be059537ec1e82f71c90d75ecba321713 # v6.1.0
         with:
-          job-results: ${{ needs.audit-casks.result }}
+          job-results: ${{ needs.audit-casks.result }} ${{ needs.test-scripts.result }}

--- a/.github/workflows/close-superseded-cask-bumps.yaml
+++ b/.github/workflows/close-superseded-cask-bumps.yaml
@@ -61,9 +61,11 @@ jobs:
               [ -n "$num" ] || continue
               # Quote the prefix so `#` strips it literally (SC2295), not as a glob pattern.
               ver="${branch#"$prefix"}"
-              # Keep a genuinely-newer pending bump; close anything at-or-below main (sort -V: if the
-              # max of {ver,current} is current, then ver <= current → superseded/redundant).
-              if [ "$(printf '%s\n%s\n' "$ver" "$current" | sort -V | tail -1)" = "$current" ]; then
+              # Keep a genuinely-newer pending bump; close anything at-or-below main. The version
+              # comparison lives in scripts/is-superseded.sh (exit 0 = superseded → close) so the
+              # destructive close/keep decision has a single, test-covered source of truth
+              # (test/is-superseded.test.sh).
+              if bash "$GITHUB_WORKSPACE/scripts/is-superseded.sh" "$ver" "$current"; then
                 echo "Closing #$num ($branch) — superseded by v$current on main"
                 # Build the body with printf so no YAML indentation leaks into the markdown.
                 body="$(printf '%s\n\n%s\n' \

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,8 +12,10 @@
 - `.github/workflows/ci.yaml` — runs `brew audit --strict --online` on every Cask (macOS) and aggregates the result into the required-checks gate (`devantler-tech/actions/aggregate-job-checks`) on `pull_request` and `merge_group`.
 - `.github/workflows/sync-labels.yaml` — weekly + on-demand GitHub label sync.
 - `.github/workflows/todos.yaml` — scans pushed-to-`main` commits for TODO comments and files issues.
-- `.github/workflows/close-superseded-cask-bumps.yaml` — closes stale `goreleaser/<cask>-v*` bump PRs whose version is at-or-below the version already on `main` (and deletes their branches), keeping only a genuinely-newer pending bump. Runs after a bump lands on `main`, daily, and on demand.
+- `.github/workflows/close-superseded-cask-bumps.yaml` — closes stale `goreleaser/<cask>-v*` bump PRs whose version is at-or-below the version already on `main` (and deletes their branches), keeping only a genuinely-newer pending bump. Runs after a bump lands on `main`, daily, and on demand. Its close/keep version comparison lives in `scripts/is-superseded.sh`.
 - `.github/dependabot.yaml` — daily `github-actions` dependency updates.
+- `scripts/is-superseded.sh` — version-comparison predicate (`<candidate> <current>` → exit 0 = superseded/close, exit 1 = newer/keep) shared by `close-superseded-cask-bumps.yaml`; the single source of truth for the destructive close/keep decision.
+- `test/is-superseded.test.sh` — hermetic regression test for `scripts/is-superseded.sh` (no network/Homebrew); run on Linux by the `ci.yaml` `🧪 Test scripts` job on every PR.
 
 Each Cask carries `version`, per-platform `sha256` + `url` pointing at the corresponding `devantler-tech/ksail` GitHub release asset, a `livecheck` skipped as auto-generated-on-release, a `binary`/`app` stanza, and a `postflight` that strips the macOS quarantine xattr.
 

--- a/scripts/is-superseded.sh
+++ b/scripts/is-superseded.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Decide whether a candidate Cask-bump version is superseded by the version already on `main`.
+#
+#   is-superseded.sh <candidate-version> <current-version>
+#     exit 0  → candidate <= current  (superseded/redundant — close its bump PR)
+#     exit 1  → candidate >  current  (genuinely newer — keep its bump PR)
+#     exit 2  → usage error (wrong number of arguments)
+#
+# This is the version-comparison predicate behind `.github/workflows/close-superseded-cask-bumps.yaml`,
+# extracted so the destructive close/keep decision has a single source of truth that
+# `test/is-superseded.test.sh` can exercise hermetically. A bug here would either orphan superseded
+# bumps (the problem the workflow solves) or — worse — CLOSE a genuinely-newer pending bump, losing a
+# release, so the comparison is pinned by tests.
+set -euo pipefail
+
+if [ "$#" -ne 2 ]; then
+  echo "usage: is-superseded.sh <candidate-version> <current-version>" >&2
+  exit 2
+fi
+
+candidate="$1"
+current="$2"
+
+# `sort -V` is version-aware — 7.9.0 < 7.53.2 and 7.100.0 > 7.99.0, where a lexical sort would be
+# wrong. If the maximum of {candidate, current} is `current`, then candidate <= current → superseded
+# (or, when equal, redundant). Otherwise candidate is the newer pending bump and is kept.
+if [ "$(printf '%s\n%s\n' "$candidate" "$current" | sort -V | tail -1)" = "$current" ]; then
+  exit 0
+fi
+exit 1

--- a/test/is-superseded.test.sh
+++ b/test/is-superseded.test.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Hermetic regression test for scripts/is-superseded.sh — the version-comparison predicate behind
+# close-superseded-cask-bumps.yaml's destructive close/keep decision. No network, no gh, no Homebrew:
+# pure version math. A bug here would either orphan superseded bumps (the problem the workflow solves)
+# or, worse, CLOSE a genuinely-newer pending bump (losing a release), so the behavior is pinned here.
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+script="$here/../scripts/is-superseded.sh"
+
+fail=0
+
+# assert_superseded <candidate> <current> — expect exit 0 (close the bump PR).
+assert_superseded() {
+  if bash "$script" "$1" "$2"; then
+    echo "ok: v$1 superseded by v$2 → close"
+  else
+    echo "FAIL: expected v$1 to be superseded by v$2 (close), but the script kept it"
+    fail=1
+  fi
+}
+
+# assert_kept <candidate> <current> — expect exit 1 (keep the bump PR).
+assert_kept() {
+  if bash "$script" "$1" "$2"; then
+    echo "FAIL: expected v$1 to be kept over v$2 (newer), but the script closed it"
+    fail=1
+  else
+    echo "ok: v$1 kept over v$2 → keep"
+  fi
+}
+
+# An older bump is superseded by the version on main.
+assert_superseded 7.39.0 7.53.2
+# The same version as main is redundant → superseded.
+assert_superseded 7.53.2 7.53.2
+# A genuinely-newer pending bump is kept (the case the workflow must never close).
+assert_kept 7.54.0 7.53.2
+# Version-aware ordering, NOT lexical: 7.9.0 < 7.53.2 (a lexical sort would rank "9" above "53").
+assert_superseded 7.9.0 7.53.2
+# Version-aware ordering, NOT lexical: 7.100.0 > 7.99.0 (a lexical sort would rank "100" below "99").
+assert_kept 7.100.0 7.99.0
+# Patch-level boundaries either side of main.
+assert_superseded 7.53.1 7.53.2
+assert_kept 7.53.3 7.53.2
+
+# Wrong argument count is a usage error (exit 2) — neither close nor keep.
+if bash "$script" 7.0.0 >/dev/null 2>&1; then
+  echo "FAIL: expected a usage error when called with a missing argument"
+  fail=1
+else
+  echo "ok: missing argument rejected with a usage error"
+fi
+
+if [ "$fail" -ne 0 ]; then
+  echo "is-superseded.test.sh: FAILURES"
+  exit 1
+fi
+echo "is-superseded.test.sh: all cases passed"


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## What

The `close-superseded-cask-bumps.yaml` workflow makes a **destructive** decision — it closes `goreleaser/<cask>-v*` bump PRs and deletes their branches — driven by an inline `sort -V` version comparison that had **no test**. A bug there would either orphan superseded bumps (the very problem the workflow solves) or, worse, **close a genuinely-newer pending bump and lose a release**. `ci.yaml`'s `brew audit` gate already has a self-test proving it enforces; the supersession math did not.

This PR gives that comparison a single, test-covered source of truth:

- **`scripts/is-superseded.sh`** — extracts the predicate verbatim: `is-superseded.sh <candidate> <current>` → exit `0` superseded (close), `1` newer (keep), `2` usage error.
- **`close-superseded-cask-bumps.yaml`** — the inline `if [ "$(… sort -V | tail -1)" = "$current" ]` now calls the script. **Behavior-preserving** — proven byte-identical to the original expression across older / equal / newer cases.
- **`test/is-superseded.test.sh`** — hermetic (no network, no `gh`, no Homebrew) regression test. Pins the version-aware ordering that a lexical sort would get wrong: `7.9.0 < 7.53.2` (close) and `7.100.0 > 7.99.0` (keep), plus equal-is-redundant, patch boundaries, and the usage-error path.
- **`ci.yaml`** — new Linux `🧪 Test scripts` job runs the test on every PR (the workflow itself only runs on push/schedule, so PRs editing the script weren't gated). Wired into the existing `CI - Required Checks` aggregate.

## Why here

Maps to homebrew-tap roadmap [#846](https://github.com/devantler-tech/homebrew-tap/issues/846) theme 2 (release-bump PR hygiene) — hardening the automation that keeps stale bumps from piling up. Pure CI/test hardening; no Cask content touched (Casks remain GoReleaser-generated `# DO NOT EDIT`).

## Validation

- `shellcheck scripts/is-superseded.sh test/is-superseded.test.sh` — clean.
- `actionlint` on both workflows — clean.
- `bash test/is-superseded.test.sh` — all 8 cases pass.
- Equivalence harness — script decision == original inline expression on all 7 representative version pairs.