### PR TITLE
docs: correct brew style offense count + link upstream goreleaser#6678

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@ Each Cask carries `version`, per-platform `sha256` + `url` pointing at the corre
 
 ## Validation
 
-CI runs `brew audit --strict --online` on every Cask and blocks merge on failure. It does **not** yet run `brew style` — the GoReleaser-generated Casks (`# DO NOT EDIT`) currently trip ~20 RuboCop style offenses (stanza order, `depends_on :macos`, modifier-`if`, blank lines) that can only be fixed in the upstream GoReleaser cask template, so a style gate would block every PR until that lands. Until then, still validate `brew style` locally:
+CI runs `brew audit --strict --online` on every Cask and blocks merge on failure. It does **not** yet run `brew style` — the GoReleaser-generated Casks (`# DO NOT EDIT`) currently trip 14 RuboCop style offenses (all auto-correctable: `Cask/StanzaOrder` ×7, `Layout/ArgumentAlignment` ×4, `Layout/EmptyLinesAroundBlockBody` ×2, `Cask/StanzaGrouping` ×1) rooted in the upstream GoReleaser cask template (tracked upstream in [goreleaser/goreleaser#6678](https://github.com/goreleaser/goreleaser/issues/6678); the partial fix in goreleaser#6466 is insufficient), so a style gate would block every PR until that ships. A tap-level `.rubocop.yml` cop-allowlist does **not** override `brew style` (it uses Homebrew's own bundled RuboCop config), so the gate stays off rather than being narrowed. Until then, still validate `brew style` locally:
 
 - If `brew` is available: `brew style ./Casks/<cask>.rb` and `brew audit --strict --online --cask <cask>`.
 - Otherwise: `ruby -c Casks/<cask>.rb` for a syntax check, plus a careful manual read.


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## What

Corrects a stale accuracy claim in `AGENTS.md` (## Validation) about the GoReleaser-generated Casks' `brew style` offenses. The note said "~20 RuboCop style offenses (stanza order, \`depends_on :macos\`, modifier-\`if\`, blank lines)" — verified live this is wrong on both count and categories.

## Verified findings (live, via `brew style` on both casks regenerated 2026-06-27 for v7.84.1)

- **14 offenses, all auto-correctable**: `Cask/StanzaOrder` ×7, `Layout/ArgumentAlignment` ×4, `Layout/EmptyLinesAroundBlockBody` ×2, `Cask/StanzaGrouping` ×1. (No `modifier-if` offenses exist.)
- All rooted in the upstream GoReleaser cask template (`internal/pipe/cask/templates/*.rb`). The partial fix in goreleaser#6466 (v2.15.0) only reordered built-in stanzas and is insufficient.
- A tap-level `.rubocop.yml` cop-allowlist does **not** take effect under `brew style` (it uses Homebrew's bundled config) — empirically tested — so the "narrowly-scoped allowlist" fallback the gate idea relied on isn't viable.

Filed the upstream root cause as **goreleaser/goreleaser#6678** and linked it from the note, so the `brew style` gate (issue #847) is now correctly tracked as blocked-on-upstream rather than vaguely "can only be fixed upstream".

## Why

`AGENTS.md` is read by Copilot code review and every future agent; a wrong offense count/category silently misleads. Docs-only, behaviour-preserving.

Refs #847

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CI validation guidance to reflect the current number of style offenses and their breakdown.
  * Clarified that `brew style` is still not run in CI and should be checked locally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->