### PR TITLE
chore: disable CodeRabbit automatic reviews

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+#
+# This repository is an auto-generated Homebrew tap: its casks are produced and
+# bumped by goreleaser/Renovate, not hand-authored, so automated code review adds
+# no value. Disable CodeRabbit's automatic PR reviews here.
+reviews:
+  auto_review:
+    enabled: false


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

Per maintainer request: this tap needs no automated code review — its casks are auto-generated and bumped by goreleaser/Renovate, not hand-authored.

Adds a declarative `.coderabbit.yaml` that turns off CodeRabbit's automatic PR reviews:

```yaml
reviews:
  auto_review:
    enabled: false
```

CodeRabbit reads this from the default branch, so automatic reviews stop once merged. (Manual `@coderabbitai` invocation still works if ever needed.)