### PR TITLE
chore: disable CodeRabbit review_status on the tap

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -2,7 +2,9 @@
 #
 # This repository is an auto-generated Homebrew tap: its casks are produced and
 # bumped by goreleaser/Renovate, not hand-authored, so automated code review adds
-# no value. Disable CodeRabbit's automatic PR reviews here.
+# no value. Disable CodeRabbit's automatic PR reviews here, and also suppress its
+# review-status (progress/summary) posts to keep the bot fully quiet on this tap.
 reviews:
+  review_status: false
   auto_review:
     enabled: false


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

Sets `reviews.review_status: false` in `.coderabbit.yaml`, per maintainer request.

The tap already disables CodeRabbit's `auto_review`; this additionally suppresses CodeRabbit's **review-status** (the review progress/summary status posts) so the bot stays fully quiet on this auto-generated tap (casks are produced/bumped by goreleaser/Renovate, not hand-authored).

```diff
 reviews:
+  review_status: false
   auto_review:
     enabled: false
```

Schema: [`reviews.review_status`](https://coderabbit.ai/integrations/schema.v2.json) (boolean, default `true`).
