### PR TITLE
fix(ci): scope cask autocorrections to pull requests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -100,6 +100,7 @@ jobs:
     runs-on: macos-latest
     permissions:
       contents: read # pushes use the App token minted below, never the job token
+      pull-requests: read # authoritative changed-file scope for same-repo autocorrection
     steps:
       - name: 🔒 Harden runner
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
@@ -164,15 +165,26 @@ jobs:
           fi
           echo "Self-test OK: the style-offending Cask was correctly rejected."
       - name: 🎨 brew style --fix (autocorrect generated Casks)
-        # May leave offenses it cannot autocorrect — the gate below decides.
+        # A pushable same-repo PR may modify only the non-deleted Casks that PR already changes.
+        # Fork/merge-group refs remain check-only: locally fix the complete tree, then the gate below
+        # deliberately fails if that produced a diff which cannot be pushed.
         id: fix
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          GH_TOKEN: ${{ github.token }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           set -euo pipefail
-          brew style --fix ./Casks/ || true
-          if git diff --quiet -- Casks/; then
-            echo "dirty=false" >> "$GITHUB_OUTPUT"
+          if [ "$EVENT_NAME" = "pull_request" ] && [ "$HEAD_REPO" = "$GITHUB_REPOSITORY" ]; then
+            bash scripts/autocorrect-pr-casks.sh "$GITHUB_REPOSITORY" "$PR_NUMBER" "$GITHUB_OUTPUT"
           else
-            echo "dirty=true" >> "$GITHUB_OUTPUT"
+            brew style --fix ./Casks/ || true
+            if git diff --quiet -- Casks/; then
+              echo "dirty=false" >> "$GITHUB_OUTPUT"
+            else
+              echo "dirty=true" >> "$GITHUB_OUTPUT"
+            fi
           fi
       - name: 📤 Commit and push autocorrections (same-repo PR branch)
         id: push
@@ -217,7 +229,11 @@ jobs:
         with:
           persist-credentials: false # read-only job; never pushes
       - name: 🧪 Run script tests
-        run: bash test/is-superseded.test.sh
+        run: |
+          set -euo pipefail
+          for test_script in test/*.test.sh; do
+            bash "$test_script"
+          done
 
   required-checks:
     name: CI - Required Checks

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -100,7 +100,6 @@ jobs:
     runs-on: macos-latest
     permissions:
       contents: read # pushes use the App token minted below, never the job token
-      pull-requests: read # authoritative changed-file scope for same-repo autocorrection
     steps:
       - name: 🔒 Harden runner
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
@@ -118,7 +117,7 @@ jobs:
           client-id: ${{ vars.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }} # zizmor: ignore[secrets-outside-env] - GitHub App token generation, no environment scoping available for app installations
           # Scope the token to this repo + contents:write only (zizmor github-app rule): the
-          # autocorrect push touches Casks/*.rb, never workflow files.
+          # autocorrect push touches exact manifest Cask paths, never workflow files.
           repositories: ${{ github.event.repository.name }}
           permission-contents: write
       # Two guarded checkouts instead of one parameterised `ref: github.head_ref` (CodeQL
@@ -129,7 +128,10 @@ jobs:
         if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          ref: ${{ github.head_ref }}
+          # Check out the event's immutable head, not the mutable branch name. The later leased push
+          # targets github.head_ref only if the remote still equals this exact SHA.
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0 # immutable three-dot base/head scope needs complete merge-base history
           persist-credentials: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
           token: ${{ steps.generate-token.outputs.token }}
       - name: 📥 Checkout (fork PR / merge_group — read-only)
@@ -170,14 +172,15 @@ jobs:
         # deliberately fails if that produced a diff which cannot be pushed.
         id: fix
         env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
           EVENT_NAME: ${{ github.event_name }}
-          GH_TOKEN: ${{ github.token }}
+          EXPECTED_HEAD: ${{ github.event.pull_request.head.sha }}
           HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
+          TARGET_MANIFEST: ${{ runner.temp }}/cask-autocorrect-targets
         run: |
           set -euo pipefail
           if [ "$EVENT_NAME" = "pull_request" ] && [ "$HEAD_REPO" = "$GITHUB_REPOSITORY" ]; then
-            bash scripts/autocorrect-pr-casks.sh "$GITHUB_REPOSITORY" "$PR_NUMBER" "$GITHUB_OUTPUT"
+            bash scripts/autocorrect-pr-casks.sh "$BASE_SHA" "$EXPECTED_HEAD" "$GITHUB_OUTPUT" "$TARGET_MANIFEST"
           else
             brew style --fix ./Casks/ || true
             if git diff --quiet -- Casks/; then
@@ -189,13 +192,45 @@ jobs:
       - name: 📤 Commit and push autocorrections (same-repo PR branch)
         id: push
         if: steps.fix.outputs.dirty == 'true' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
-        uses: stefanzweifel/git-auto-commit-action@4a55954c782fc1ea30b9056cd3e7a2b40ca8887d # v7.2.0
-        with:
-          commit_message: "style: autocorrect Casks (brew style --fix)"
-          commit_user_name: generator-bot
-          commit_user_email: generator-bot@users.noreply.github.com
-          branch: ${{ github.head_ref }}
-          file_pattern: "Casks/*.rb"
+        env:
+          EXPECTED_HEAD: ${{ github.event.pull_request.head.sha }}
+          HEAD_REF: ${{ github.head_ref }}
+          TARGET_MANIFEST: ${{ runner.temp }}/cask-autocorrect-targets
+        run: |
+          set -euo pipefail
+          if [[ ! "$EXPECTED_HEAD" =~ ^[0-9a-f]{40}$ ]] \
+            || ! git check-ref-format "refs/heads/$HEAD_REF" >/dev/null; then
+            echo "::error::Invalid event head or pull-request branch"
+            exit 1
+          fi
+          if [ "$(git rev-parse HEAD)" != "$EXPECTED_HEAD" ] || [ ! -s "$TARGET_MANIFEST" ]; then
+            echo "::error::Checkout or target manifest is not bound to the event head"
+            exit 1
+          fi
+
+          # Stage only the helper's post-guard manifest. The sentinel keeps Bash 3.2 nounset-safe.
+          targets=("")
+          while IFS= read -r target; do
+            if [[ ! "$target" =~ ^Casks/[A-Za-z0-9][A-Za-z0-9._+-]*\.rb$ ]] \
+              || [ ! -f "$target" ]; then
+              echo "::error::Unsafe target manifest path: $target"
+              exit 1
+            fi
+            git add -- "$target"
+            targets+=("$target")
+          done <"$TARGET_MANIFEST"
+          if [ "${#targets[@]}" -le 1 ] || git diff --cached --quiet -- "${targets[@]:1}"; then
+            echo "::error::Target manifest produced no staged Cask correction"
+            exit 1
+          fi
+
+          git config user.name generator-bot
+          git config user.email generator-bot@users.noreply.github.com
+          git commit -m "style: autocorrect Casks (brew style --fix)" -- "${targets[@]:1}"
+
+          # Exact compare-and-swap: a branch reset or sibling push after checkout rejects this push,
+          # even when the stale local commit would otherwise be a valid fast-forward.
+          git push --force-with-lease="refs/heads/$HEAD_REF:$EXPECTED_HEAD" origin "HEAD:refs/heads/$HEAD_REF"
       - name: 🎨 brew style (gate)
         # A dirty tree this run could NOT push back (merge_group / fork PR) must fail — passing on
         # the locally-fixed tree would greenlight a style-dirty head SHA. When the autocorrect WAS

--- a/Casks/ksail.rb
+++ b/Casks/ksail.rb
@@ -6,7 +6,7 @@ cask "ksail" do
     on_arm do
       sha256 "417d341cb4a2f91faef4cdade30772ed0f8dc74fee754f5e30681893853d0b6c"
       url "https://github.com/devantler-tech/ksail/releases/download/v#{version}/ksail_#{version}_darwin_arm64.tar.gz",
-        verified: "github.com/devantler-tech/ksail/"
+          verified: "github.com/devantler-tech/ksail/"
     end
   end
 
@@ -14,12 +14,12 @@ cask "ksail" do
     on_intel do
       sha256 "6aff69180cdd34477d9c667b1761f117c371d5ed24d04ae2212e29da00f05093"
       url "https://github.com/devantler-tech/ksail/releases/download/v#{version}/ksail_#{version}_linux_amd64.tar.gz",
-        verified: "github.com/devantler-tech/ksail/"
+          verified: "github.com/devantler-tech/ksail/"
     end
     on_arm do
       sha256 "ea1e0cec9de8d94a3c5b047fac62ae57186681effca3b389e1f83f1301b4541a"
       url "https://github.com/devantler-tech/ksail/releases/download/v#{version}/ksail_#{version}_linux_arm64.tar.gz",
-        verified: "github.com/devantler-tech/ksail/"
+          verified: "github.com/devantler-tech/ksail/"
     end
   end
 
@@ -38,5 +38,4 @@ cask "ksail" do
   end
 
   # No zap stanza required
-
 end

--- a/scripts/autocorrect-pr-casks.sh
+++ b/scripts/autocorrect-pr-casks.sh
@@ -1,39 +1,55 @@
 #!/usr/bin/env bash
-# Autocorrect only the non-deleted Casks already changed by one pull request.
+# Autocorrect only Casks changed between one immutable pull-request base/head pair.
 #
-# A same-repository PR may receive a generated style commit, but that privilege must never widen the
-# PR into another Cask. The caller may safely use a broad Casks/*.rb commit pattern only after this
-# script's post-fix scope guard succeeds.
+# The workflow checks out the event head with full history, and the eventual push uses a lease pinned
+# to that same head. This helper derives scope locally with NUL-delimited Git paths, so a mutable PR
+# branch or a filename containing newlines cannot change or split the authorization boundary.
 set -euo pipefail
 
-if [ "$#" -ne 3 ]; then
-  echo "usage: autocorrect-pr-casks.sh <owner/repo> <pr-number> <github-output>" >&2
+if [ "$#" -ne 4 ]; then
+  echo "usage: autocorrect-pr-casks.sh <base-sha> <head-sha> <github-output> <target-manifest>" >&2
   exit 2
 fi
 
-repository="$1"
-pr_number="$2"
+base_sha="$1"
+expected_head="$2"
 github_output="$3"
+target_manifest="$4"
 
-if [[ ! "$repository" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]; then
-  echo "BLOCKED: invalid repository name: $repository" >&2
-  exit 2
-fi
-if [[ ! "$pr_number" =~ ^[1-9][0-9]*$ ]]; then
-  echo "BLOCKED: invalid pull request number: $pr_number" >&2
-  exit 2
-fi
-if [ -z "$github_output" ]; then
-  echo "BLOCKED: the GitHub output path is empty" >&2
+for named_sha in "base:$base_sha" "head:$expected_head"; do
+  sha_name="${named_sha%%:*}"
+  sha_value="${named_sha#*:}"
+  if [[ ! "$sha_value" =~ ^[0-9a-f]{40}$ ]]; then
+    echo "BLOCKED: invalid $sha_name commit SHA: $sha_value" >&2
+    exit 2
+  fi
+done
+if [ -z "$github_output" ] || [ -z "$target_manifest" ]; then
+  echo "BLOCKED: output and target-manifest paths are required" >&2
   exit 2
 fi
 
-# The PR-files endpoint is the authoritative scope. It is paginated, excludes deleted Casks that no
-# longer exist in the checkout, and fails closed before Homebrew can mutate anything.
-if ! changed_files="$(gh api --paginate \
-  "repos/${repository}/pulls/${pr_number}/files?per_page=100" \
-  --jq '.[] | select(.status != "removed") | .filename')"; then
-  echo "BLOCKED: could not enumerate changed files for ${repository}#${pr_number}" >&2
+if ! local_head="$(git rev-parse HEAD)" || [ "$local_head" != "$expected_head" ]; then
+  echo "BLOCKED: checkout HEAD ${local_head:-unavailable} does not equal event head $expected_head" >&2
+  exit 1
+fi
+if ! git cat-file -e "${base_sha}^{commit}" 2>/dev/null \
+  || ! git cat-file -e "${expected_head}^{commit}" 2>/dev/null; then
+  echo "BLOCKED: immutable base/head history is unavailable" >&2
+  exit 1
+fi
+if ! merge_base="$(git merge-base "$base_sha" "$expected_head")" || [ -z "$merge_base" ]; then
+  echo "BLOCKED: could not resolve the pull-request merge base" >&2
+  exit 1
+fi
+
+changed_paths="$(mktemp)"
+trap 'rm -f "$changed_paths"' EXIT
+# Match GitHub's three-dot PR scope from immutable commits. Exclude deletions because a deleted Cask
+# has no working-tree path to style. `-z` preserves every filename boundary, including newlines.
+if ! git diff --name-only -z --diff-filter=ACMRTUXB \
+  "$merge_base" "$expected_head" -- >"$changed_paths"; then
+  echo "BLOCKED: could not enumerate immutable changed paths" >&2
   exit 1
 fi
 
@@ -41,12 +57,11 @@ fi
 # Keep an inert sentinel at index 0 and pass only the slice beginning at index 1.
 targets=("")
 target_count=0
-while IFS= read -r changed_file; do
-  [ -z "$changed_file" ] && continue
+while IFS= read -r -d '' changed_file; do
   case "$changed_file" in
-    Casks/*.rb)
+    Casks/*)
       # Casks are single files directly beneath Casks/. Reject nested paths, shell metacharacters,
-      # whitespace, and missing files rather than passing an ambiguous argument to Homebrew.
+      # whitespace/newlines, and missing files rather than interpreting an ambiguous path.
       if [[ ! "$changed_file" =~ ^Casks/[A-Za-z0-9][A-Za-z0-9._+-]*\.rb$ ]] \
         || [ ! -f "$changed_file" ]; then
         echo "BLOCKED: unsafe or missing changed Cask path: $changed_file" >&2
@@ -65,19 +80,18 @@ while IFS= read -r changed_file; do
       fi
       ;;
   esac
-done <<EOF
-$changed_files
-EOF
+done <"$changed_paths"
 
+# The commit step stages only paths written here after the post-fix status guard succeeds.
+: >"$target_manifest"
 if [ "$target_count" -eq 0 ]; then
-  echo "No changed Casks to autocorrect for ${repository}#${pr_number}"
+  echo "No changed Casks to autocorrect for $expected_head"
   printf 'dirty=false\n' >>"$github_output"
   exit 0
 fi
 
 # A dirty start would make the post-fix allowlist ambiguous. Porcelain status includes tracked,
-# staged, and untracked paths; `git diff` alone omits the latter two and would let the broad commit
-# action pick up state this helper never authorized.
+# staged, and untracked paths; `git diff` alone omits the latter two.
 if ! initial_status="$(git status --porcelain=v1 --untracked-files=all -- Casks/)"; then
   echo "BLOCKED: could not inspect initial Cask status" >&2
   exit 1
@@ -87,7 +101,7 @@ if [ -n "$initial_status" ]; then
   exit 1
 fi
 
-echo "Autocorrecting PR-scoped Casks: ${targets[*]:1}"
+echo "Autocorrecting immutable PR-scoped Casks: ${targets[*]:1}"
 # Homebrew can apply partial fixes and still return non-zero for remaining offenses. Preserve those
 # corrections; the later full-tree `brew style` gate decides whether any offense remains.
 brew style --fix "${targets[@]:1}" || true
@@ -97,7 +111,7 @@ if ! cask_status="$(git status --porcelain=v1 --untracked-files=all -- Casks/)";
   exit 1
 fi
 
-dirty_files=""
+dirty_count=0
 while IFS= read -r status_line; do
   [ -z "$status_line" ] && continue
   if [ "${#status_line}" -lt 4 ]; then
@@ -108,8 +122,7 @@ while IFS= read -r status_line; do
   dirty_file="${status_line:3}"
 
   # Homebrew should only leave an unstaged modification to an existing target. Reject staged,
-  # untracked, deleted, renamed, copied, or conflicted state outright; the pinned commit action
-  # would otherwise stage those paths through its broad Casks/*.rb file pattern.
+  # untracked, deleted, renamed, copied, conflicted, malformed, and out-of-scope state outright.
   if [ "$index_and_worktree" != " M" ]; then
     echo "BLOCKED: autocorrection produced unsafe Cask status '$index_and_worktree' for $dirty_file" >&2
     exit 1
@@ -125,17 +138,13 @@ while IFS= read -r status_line; do
     echo "BLOCKED: autocorrection dirtied out-of-scope Cask: $dirty_file" >&2
     exit 1
   fi
-  if [ -z "$dirty_files" ]; then
-    dirty_files="$dirty_file"
-  else
-    dirty_files="$dirty_files
-$dirty_file"
-  fi
+  printf '%s\n' "$dirty_file" >>"$target_manifest"
+  dirty_count=$((dirty_count + 1))
 done <<EOF
 $cask_status
 EOF
 
-if [ -z "$dirty_files" ]; then
+if [ "$dirty_count" -eq 0 ]; then
   printf 'dirty=false\n' >>"$github_output"
 else
   printf 'dirty=true\n' >>"$github_output"

--- a/scripts/autocorrect-pr-casks.sh
+++ b/scripts/autocorrect-pr-casks.sh
@@ -75,9 +75,14 @@ if [ "$target_count" -eq 0 ]; then
   exit 0
 fi
 
-# A dirty start would make the post-fix allowlist ambiguous. The Actions checkout is expected to be
-# clean, so stop rather than accidentally attributing an earlier mutation to this autocorrect pass.
-if ! git diff --quiet -- Casks/; then
+# A dirty start would make the post-fix allowlist ambiguous. Porcelain status includes tracked,
+# staged, and untracked paths; `git diff` alone omits the latter two and would let the broad commit
+# action pick up state this helper never authorized.
+if ! initial_status="$(git status --porcelain=v1 --untracked-files=all -- Casks/)"; then
+  echo "BLOCKED: could not inspect initial Cask status" >&2
+  exit 1
+fi
+if [ -n "$initial_status" ]; then
   echo "BLOCKED: Casks were already dirty before autocorrection" >&2
   exit 1
 fi
@@ -87,13 +92,28 @@ echo "Autocorrecting PR-scoped Casks: ${targets[*]:1}"
 # corrections; the later full-tree `brew style` gate decides whether any offense remains.
 brew style --fix "${targets[@]:1}" || true
 
-if ! dirty_files="$(git diff --name-only -- Casks/)"; then
-  echo "BLOCKED: could not enumerate autocorrection changes" >&2
+if ! cask_status="$(git status --porcelain=v1 --untracked-files=all -- Casks/)"; then
+  echo "BLOCKED: could not enumerate autocorrection status" >&2
   exit 1
 fi
 
-while IFS= read -r dirty_file; do
-  [ -z "$dirty_file" ] && continue
+dirty_files=""
+while IFS= read -r status_line; do
+  [ -z "$status_line" ] && continue
+  if [ "${#status_line}" -lt 4 ]; then
+    echo "BLOCKED: malformed Cask status: $status_line" >&2
+    exit 1
+  fi
+  index_and_worktree="${status_line:0:2}"
+  dirty_file="${status_line:3}"
+
+  # Homebrew should only leave an unstaged modification to an existing target. Reject staged,
+  # untracked, deleted, renamed, copied, or conflicted state outright; the pinned commit action
+  # would otherwise stage those paths through its broad Casks/*.rb file pattern.
+  if [ "$index_and_worktree" != " M" ]; then
+    echo "BLOCKED: autocorrection produced unsafe Cask status '$index_and_worktree' for $dirty_file" >&2
+    exit 1
+  fi
   allowed=0
   for target in "${targets[@]:1}"; do
     if [ "$target" = "$dirty_file" ]; then
@@ -105,8 +125,14 @@ while IFS= read -r dirty_file; do
     echo "BLOCKED: autocorrection dirtied out-of-scope Cask: $dirty_file" >&2
     exit 1
   fi
+  if [ -z "$dirty_files" ]; then
+    dirty_files="$dirty_file"
+  else
+    dirty_files="$dirty_files
+$dirty_file"
+  fi
 done <<EOF
-$dirty_files
+$cask_status
 EOF
 
 if [ -z "$dirty_files" ]; then

--- a/scripts/autocorrect-pr-casks.sh
+++ b/scripts/autocorrect-pr-casks.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# Autocorrect only the non-deleted Casks already changed by one pull request.
+#
+# A same-repository PR may receive a generated style commit, but that privilege must never widen the
+# PR into another Cask. The caller may safely use a broad Casks/*.rb commit pattern only after this
+# script's post-fix scope guard succeeds.
+set -euo pipefail
+
+if [ "$#" -ne 3 ]; then
+  echo "usage: autocorrect-pr-casks.sh <owner/repo> <pr-number> <github-output>" >&2
+  exit 2
+fi
+
+repository="$1"
+pr_number="$2"
+github_output="$3"
+
+if [[ ! "$repository" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]; then
+  echo "BLOCKED: invalid repository name: $repository" >&2
+  exit 2
+fi
+if [[ ! "$pr_number" =~ ^[1-9][0-9]*$ ]]; then
+  echo "BLOCKED: invalid pull request number: $pr_number" >&2
+  exit 2
+fi
+if [ -z "$github_output" ]; then
+  echo "BLOCKED: the GitHub output path is empty" >&2
+  exit 2
+fi
+
+# The PR-files endpoint is the authoritative scope. It is paginated, excludes deleted Casks that no
+# longer exist in the checkout, and fails closed before Homebrew can mutate anything.
+if ! changed_files="$(gh api --paginate \
+  "repos/${repository}/pulls/${pr_number}/files?per_page=100" \
+  --jq '.[] | select(.status != "removed") | .filename')"; then
+  echo "BLOCKED: could not enumerate changed files for ${repository}#${pr_number}" >&2
+  exit 1
+fi
+
+# Bash 3.2 (the macOS runner default) treats an empty array expansion as unset under `set -u`.
+# Keep an inert sentinel at index 0 and pass only the slice beginning at index 1.
+targets=("")
+target_count=0
+while IFS= read -r changed_file; do
+  [ -z "$changed_file" ] && continue
+  case "$changed_file" in
+    Casks/*.rb)
+      # Casks are single files directly beneath Casks/. Reject nested paths, shell metacharacters,
+      # whitespace, and missing files rather than passing an ambiguous argument to Homebrew.
+      if [[ ! "$changed_file" =~ ^Casks/[A-Za-z0-9][A-Za-z0-9._+-]*\.rb$ ]] \
+        || [ ! -f "$changed_file" ]; then
+        echo "BLOCKED: unsafe or missing changed Cask path: $changed_file" >&2
+        exit 1
+      fi
+      duplicate=0
+      for target in "${targets[@]:1}"; do
+        if [ "$target" = "$changed_file" ]; then
+          duplicate=1
+          break
+        fi
+      done
+      if [ "$duplicate" -eq 0 ]; then
+        targets+=("$changed_file")
+        target_count=$((target_count + 1))
+      fi
+      ;;
+  esac
+done <<EOF
+$changed_files
+EOF
+
+if [ "$target_count" -eq 0 ]; then
+  echo "No changed Casks to autocorrect for ${repository}#${pr_number}"
+  printf 'dirty=false\n' >>"$github_output"
+  exit 0
+fi
+
+# A dirty start would make the post-fix allowlist ambiguous. The Actions checkout is expected to be
+# clean, so stop rather than accidentally attributing an earlier mutation to this autocorrect pass.
+if ! git diff --quiet -- Casks/; then
+  echo "BLOCKED: Casks were already dirty before autocorrection" >&2
+  exit 1
+fi
+
+echo "Autocorrecting PR-scoped Casks: ${targets[*]:1}"
+# Homebrew can apply partial fixes and still return non-zero for remaining offenses. Preserve those
+# corrections; the later full-tree `brew style` gate decides whether any offense remains.
+brew style --fix "${targets[@]:1}" || true
+
+if ! dirty_files="$(git diff --name-only -- Casks/)"; then
+  echo "BLOCKED: could not enumerate autocorrection changes" >&2
+  exit 1
+fi
+
+while IFS= read -r dirty_file; do
+  [ -z "$dirty_file" ] && continue
+  allowed=0
+  for target in "${targets[@]:1}"; do
+    if [ "$target" = "$dirty_file" ]; then
+      allowed=1
+      break
+    fi
+  done
+  if [ "$allowed" -ne 1 ]; then
+    echo "BLOCKED: autocorrection dirtied out-of-scope Cask: $dirty_file" >&2
+    exit 1
+  fi
+done <<EOF
+$dirty_files
+EOF
+
+if [ -z "$dirty_files" ]; then
+  printf 'dirty=false\n' >>"$github_output"
+else
+  printf 'dirty=true\n' >>"$github_output"
+fi

--- a/test/autocorrect-pr-casks.test.sh
+++ b/test/autocorrect-pr-casks.test.sh
@@ -1,0 +1,214 @@
+#!/usr/bin/env bash
+# Hermetic regression tests for the PR-scoped Cask autocorrector. The workflow may push generated
+# style fixes to a trusted same-repository PR, so widening one Cask PR into another Cask is a release
+# safety failure, not cosmetic drift.
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+script="$here/../scripts/autocorrect-pr-casks.sh"
+scratch="$(mktemp -d)"
+trap 'rm -rf "$scratch"' EXIT
+fail=0
+
+new_fixture() {
+  local root="$scratch/$1"
+  mkdir -p "$root/Casks" "$root/bin"
+  printf 'needs-style-fix\n' >"$root/Casks/target.rb"
+  printf 'needs-style-fix\n' >"$root/Casks/sibling.rb"
+  printf 'fixture\n' >"$root/README.md"
+
+  cat >"$root/bin/gh" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >"$GH_ARGS_FILE"
+if [ "${GH_FAIL:-0}" = 1 ]; then
+  exit 1
+fi
+printf '%s' "${GH_FILES:-}"
+STUB
+  cat >"$root/bin/brew" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >"$BREW_ARGS_FILE"
+if [ "$1" != style ] || [ "$2" != --fix ]; then
+  echo "unexpected brew invocation: $*" >&2
+  exit 2
+fi
+shift 2
+for target in "$@"; do
+  printf 'fixed\n' >>"$target"
+done
+if [ "${BREW_MUTATE_OUTSIDE:-0}" = 1 ]; then
+  printf 'wrong-scope\n' >>Casks/sibling.rb
+fi
+exit "${BREW_EXIT:-0}"
+STUB
+  chmod +x "$root/bin/gh" "$root/bin/brew"
+
+  (
+    cd "$root"
+    git init -q
+    git config user.name fixture
+    git config user.email fixture@example.invalid
+    git add Casks/target.rb Casks/sibling.rb README.md
+    git commit -qm fixture
+  )
+  printf '%s\n' "$root"
+}
+
+assert_pr_scoped_fix() {
+  local root output dirty
+  root="$(new_fixture scoped)"
+  output="$root/output"
+  (
+    cd "$root"
+    PATH="$root/bin:$PATH" \
+      GH_ARGS_FILE="$root/gh.args" \
+      BREW_ARGS_FILE="$root/brew.args" \
+      GH_FILES=$'Casks/target.rb\nREADME.md\n' \
+      bash "$script" devantler-tech/homebrew-tap 42 "$output"
+  )
+
+  dirty="$(sed -n 's/^dirty=//p' "$output")"
+  if [ "$dirty" != true ]; then
+    echo "FAIL: expected a changed target to emit dirty=true"
+    fail=1
+  elif ! grep -Fqx 'style --fix Casks/target.rb' "$root/brew.args"; then
+    echo "FAIL: brew did not receive only the PR-changed Cask"
+    fail=1
+  elif ! grep -Fqx 'needs-style-fix' "$root/Casks/sibling.rb"; then
+    echo "FAIL: the unrelated style-dirty Cask was modified"
+    fail=1
+  elif [ "$(cd "$root" && git diff --name-only -- Casks/)" != 'Casks/target.rb' ]; then
+    echo "FAIL: autocorrection dirtied a file outside the PR Cask"
+    fail=1
+  elif ! grep -Fq -- '--paginate repos/devantler-tech/homebrew-tap/pulls/42/files?per_page=100' "$root/gh.args" \
+    || ! grep -Fq 'select(.status != "removed")' "$root/gh.args"; then
+    echo "FAIL: changed-file discovery is not paginated or does not exclude removed Casks"
+    fail=1
+  else
+    echo "ok: same-repository autocorrection touches only the PR-changed Cask"
+  fi
+}
+
+assert_api_failure_is_fatal() {
+  local root
+  root="$(new_fixture api-failure)"
+  if (
+    cd "$root"
+    PATH="$root/bin:$PATH" \
+      GH_ARGS_FILE="$root/gh.args" \
+      BREW_ARGS_FILE="$root/brew.args" \
+      GH_FAIL=1 \
+      bash "$script" devantler-tech/homebrew-tap 42 "$root/output"
+  ) >/dev/null 2>&1; then
+    echo "FAIL: changed-file API failure was accepted"
+    fail=1
+  elif [ -e "$root/brew.args" ]; then
+    echo "FAIL: brew ran after changed-file discovery failed"
+    fail=1
+  else
+    echo "ok: changed-file discovery failure stops before autocorrection"
+  fi
+}
+
+assert_unsafe_path_is_fatal() {
+  local root
+  root="$(new_fixture unsafe-path)"
+  if (
+    cd "$root"
+    PATH="$root/bin:$PATH" \
+      GH_ARGS_FILE="$root/gh.args" \
+      BREW_ARGS_FILE="$root/brew.args" \
+      GH_FILES=$'Casks/nested/escape.rb\n' \
+      bash "$script" devantler-tech/homebrew-tap 42 "$root/output"
+  ) >/dev/null 2>&1; then
+    echo "FAIL: an unsafe nested Cask path was accepted"
+    fail=1
+  elif [ -e "$root/brew.args" ]; then
+    echo "FAIL: brew ran after an unsafe Cask path was discovered"
+    fail=1
+  else
+    echo "ok: unsafe Cask paths fail closed before autocorrection"
+  fi
+}
+
+assert_out_of_scope_mutation_is_fatal() {
+  local root
+  root="$(new_fixture scope-escape)"
+  if (
+    cd "$root"
+    PATH="$root/bin:$PATH" \
+      GH_ARGS_FILE="$root/gh.args" \
+      BREW_ARGS_FILE="$root/brew.args" \
+      GH_FILES=$'Casks/target.rb\n' \
+      BREW_MUTATE_OUTSIDE=1 \
+      bash "$script" devantler-tech/homebrew-tap 42 "$root/output"
+  ) >/dev/null 2>&1; then
+    echo "FAIL: autocorrection was allowed to dirty an unrelated Cask"
+    fail=1
+  else
+    echo "ok: scope guard rejects an autocorrector that dirties another Cask"
+  fi
+}
+
+assert_no_cask_is_noop() {
+  local root dirty
+  root="$(new_fixture no-cask)"
+  (
+    cd "$root"
+    PATH="$root/bin:$PATH" \
+      GH_ARGS_FILE="$root/gh.args" \
+      BREW_ARGS_FILE="$root/brew.args" \
+      GH_FILES=$'README.md\n' \
+      bash "$script" devantler-tech/homebrew-tap 42 "$root/output"
+  )
+  dirty="$(sed -n 's/^dirty=//p' "$root/output")"
+  if [ "$dirty" != false ] || [ -e "$root/brew.args" ]; then
+    echo "FAIL: a PR without Cask changes was not a clean no-op"
+    fail=1
+  else
+    echo "ok: a PR without changed Casks is a clean no-op"
+  fi
+}
+
+assert_workflow_contract() {
+  local workflow fix_block
+  workflow="$here/../.github/workflows/ci.yaml"
+  fix_block="$(sed -n '/- name: 🎨 brew style --fix/,/- name: 📤 Commit/p' "$workflow")"
+
+  # Literal GitHub/shell expressions are the workflow contract, not values for this test to expand.
+  # shellcheck disable=SC2016
+  if ! grep -Fq 'pull-requests: read' "$workflow"; then
+    echo "FAIL: style job cannot read the authoritative PR file list"
+    fail=1
+  elif ! grep -Fq 'GH_TOKEN: ${{ github.token }}' <<<"$fix_block"; then
+    echo "FAIL: PR-scoped autocorrection does not use the read-only workflow token"
+    fail=1
+  elif ! grep -Fq 'if [ "$EVENT_NAME" = "pull_request" ] && [ "$HEAD_REPO" = "$GITHUB_REPOSITORY" ]; then' <<<"$fix_block"; then
+    echo "FAIL: same-repository PR autocorrection is not explicitly gated"
+    fail=1
+  elif ! grep -Fq 'bash scripts/autocorrect-pr-casks.sh "$GITHUB_REPOSITORY" "$PR_NUMBER" "$GITHUB_OUTPUT"' <<<"$fix_block"; then
+    echo "FAIL: the workflow does not delegate same-repository fixes to the scoped helper"
+    fail=1
+  elif ! grep -Fq 'brew style --fix ./Casks/ || true' <<<"$fix_block"; then
+    echo "FAIL: the check-only fallback no longer evaluates the complete Cask tree"
+    fail=1
+  elif ! grep -Fq 'for test_script in test/*.test.sh; do' "$workflow"; then
+    echo "FAIL: CI does not execute every hermetic script regression test"
+    fail=1
+  else
+    echo "ok: workflow scopes pushable PR fixes and retains the full-tree check-only gate"
+  fi
+}
+
+assert_pr_scoped_fix
+assert_api_failure_is_fatal
+assert_unsafe_path_is_fatal
+assert_out_of_scope_mutation_is_fatal
+assert_no_cask_is_noop
+assert_workflow_contract
+
+if [ "$fail" -ne 0 ]; then
+  echo "autocorrect-pr-casks.test.sh: FAILURES"
+  exit 1
+fi
+echo "autocorrect-pr-casks.test.sh: all cases passed"

--- a/test/autocorrect-pr-casks.test.sh
+++ b/test/autocorrect-pr-casks.test.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
-# Hermetic regression tests for the PR-scoped Cask autocorrector. The workflow may push generated
-# style fixes to a trusted same-repository PR, so widening one Cask PR into another Cask is a release
-# safety failure, not cosmetic drift.
+# Hermetic regression tests for the PR-scoped Cask autocorrector. Pushable style commits must be
+# bound to one immutable event head and must never widen a generated Cask PR.
 set -euo pipefail
 
 here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -17,14 +16,6 @@ new_fixture() {
   printf 'needs-style-fix\n' >"$root/Casks/sibling.rb"
   printf 'fixture\n' >"$root/README.md"
 
-  cat >"$root/bin/gh" <<'STUB'
-#!/usr/bin/env bash
-printf '%s\n' "$*" >"$GH_ARGS_FILE"
-if [ "${GH_FAIL:-0}" = 1 ]; then
-  exit 1
-fi
-printf '%s' "${GH_FILES:-}"
-STUB
   cat >"$root/bin/brew" <<'STUB'
 #!/usr/bin/env bash
 printf '%s\n' "$*" >"$BREW_ARGS_FILE"
@@ -44,7 +35,7 @@ if [ "${BREW_CREATE_UNTRACKED:-0}" = 1 ]; then
 fi
 exit "${BREW_EXIT:-0}"
 STUB
-  chmod +x "$root/bin/gh" "$root/bin/brew"
+  chmod +x "$root/bin/brew"
 
   (
     cd "$root"
@@ -57,95 +48,121 @@ STUB
   printf '%s\n' "$root"
 }
 
-assert_pr_scoped_fix() {
-  local root output dirty
-  root="$(new_fixture scoped)"
-  output="$root/output"
+commit_target_change() {
+  local root="$1"
+  (
+    cd "$root"
+    printf 'generated-update\n' >>Casks/target.rb
+    git add Casks/target.rb
+    git commit -qm generated-target
+  )
+}
+
+run_helper() {
+  local root="$1" base="$2" head="$3"
   (
     cd "$root"
     PATH="$root/bin:$PATH" \
-      GH_ARGS_FILE="$root/gh.args" \
       BREW_ARGS_FILE="$root/brew.args" \
-      GH_FILES=$'Casks/target.rb\nREADME.md\n' \
-      bash "$script" devantler-tech/homebrew-tap 42 "$output"
+      bash "$script" "$base" "$head" "$root/output" "$root/targets"
   )
+}
 
-  dirty="$(sed -n 's/^dirty=//p' "$output")"
+assert_pr_scoped_fix() {
+  local root base head dirty
+  root="$(new_fixture scoped)"
+  base="$(cd "$root" && git rev-parse HEAD)"
+  commit_target_change "$root"
+  head="$(cd "$root" && git rev-parse HEAD)"
+
+  if ! run_helper "$root" "$base" "$head"; then
+    echo "FAIL: immutable target discovery rejected a valid Cask change"
+    fail=1
+    return
+  fi
+  dirty="$(sed -n 's/^dirty=//p' "$root/output")"
   if [ "$dirty" != true ]; then
     echo "FAIL: expected a changed target to emit dirty=true"
     fail=1
   elif ! grep -Fqx 'style --fix Casks/target.rb' "$root/brew.args"; then
-    echo "FAIL: brew did not receive only the PR-changed Cask"
+    echo "FAIL: brew did not receive only the changed Cask"
+    fail=1
+  elif ! grep -Fqx 'Casks/target.rb' "$root/targets"; then
+    echo "FAIL: the exact dirty target was not written to the commit manifest"
     fail=1
   elif ! grep -Fqx 'needs-style-fix' "$root/Casks/sibling.rb"; then
     echo "FAIL: the unrelated style-dirty Cask was modified"
     fail=1
-  elif [ "$(cd "$root" && git diff --name-only -- Casks/)" != 'Casks/target.rb' ]; then
-    echo "FAIL: autocorrection dirtied a file outside the PR Cask"
-    fail=1
-  elif ! grep -Fq -- '--paginate repos/devantler-tech/homebrew-tap/pulls/42/files?per_page=100' "$root/gh.args" \
-    || ! grep -Fq 'select(.status != "removed")' "$root/gh.args"; then
-    echo "FAIL: changed-file discovery is not paginated or does not exclude removed Casks"
-    fail=1
   else
-    echo "ok: same-repository autocorrection touches only the PR-changed Cask"
+    echo "ok: immutable diff autocorrects and manifests only the changed Cask"
   fi
 }
 
-assert_api_failure_is_fatal() {
-  local root
-  root="$(new_fixture api-failure)"
-  if (
-    cd "$root"
-    PATH="$root/bin:$PATH" \
-      GH_ARGS_FILE="$root/gh.args" \
-      BREW_ARGS_FILE="$root/brew.args" \
-      GH_FAIL=1 \
-      bash "$script" devantler-tech/homebrew-tap 42 "$root/output"
-  ) >/dev/null 2>&1; then
-    echo "FAIL: changed-file API failure was accepted"
+assert_missing_history_is_fatal() {
+  local root head missing
+  root="$(new_fixture missing-history)"
+  commit_target_change "$root"
+  head="$(cd "$root" && git rev-parse HEAD)"
+  missing='ffffffffffffffffffffffffffffffffffffffff'
+  if run_helper "$root" "$missing" "$head" >/dev/null 2>&1; then
+    echo "FAIL: missing base history was accepted"
     fail=1
   elif [ -e "$root/brew.args" ]; then
-    echo "FAIL: brew ran after changed-file discovery failed"
+    echo "FAIL: brew ran after immutable history discovery failed"
     fail=1
   else
-    echo "ok: changed-file discovery failure stops before autocorrection"
+    echo "ok: missing immutable history stops before autocorrection"
   fi
 }
 
-assert_unsafe_path_is_fatal() {
-  local root
-  root="$(new_fixture unsafe-path)"
-  if (
-    cd "$root"
-    PATH="$root/bin:$PATH" \
-      GH_ARGS_FILE="$root/gh.args" \
-      BREW_ARGS_FILE="$root/brew.args" \
-      GH_FILES=$'Casks/nested/escape.rb\n' \
-      bash "$script" devantler-tech/homebrew-tap 42 "$root/output"
-  ) >/dev/null 2>&1; then
-    echo "FAIL: an unsafe nested Cask path was accepted"
+assert_checked_out_head_mismatch_is_fatal() {
+  local root base head
+  root="$(new_fixture head-mismatch)"
+  base="$(cd "$root" && git rev-parse HEAD)"
+  commit_target_change "$root"
+  head="$(cd "$root" && git rev-parse HEAD)"
+  if run_helper "$root" "$base" "$base" >/dev/null 2>&1; then
+    echo "FAIL: a checkout that differs from the event head was accepted"
     fail=1
   elif [ -e "$root/brew.args" ]; then
-    echo "FAIL: brew ran after an unsafe Cask path was discovered"
+    echo "FAIL: brew ran after the checked-out head mismatched the event head $head"
     fail=1
   else
-    echo "ok: unsafe Cask paths fail closed before autocorrection"
+    echo "ok: mutable-head checkout mismatch fails before autocorrection"
+  fi
+}
+
+assert_newline_path_is_fatal() {
+  local root base head unsafe_dir
+  root="$(new_fixture newline-path)"
+  base="$(cd "$root" && git rev-parse HEAD)"
+  unsafe_dir="$root/"$'Casks/target.rb\nCasks'
+  mkdir -p "$unsafe_dir"
+  printf 'one-filename-not-two\n' >"$unsafe_dir/sibling.rb"
+  (
+    cd "$root"
+    git add "$unsafe_dir/sibling.rb"
+    git commit -qm newline-path
+  )
+  head="$(cd "$root" && git rev-parse HEAD)"
+  if run_helper "$root" "$base" "$head" >/dev/null 2>&1; then
+    echo "FAIL: a newline-bearing Git filename split into authorized targets"
+    fail=1
+  elif [ -e "$root/brew.args" ]; then
+    echo "FAIL: brew ran after an unsafe newline-bearing path was discovered"
+    fail=1
+  else
+    echo "ok: NUL-delimited discovery preserves and rejects newline-bearing filenames"
   fi
 }
 
 assert_out_of_scope_mutation_is_fatal() {
-  local root
+  local root base head
   root="$(new_fixture scope-escape)"
-  if (
-    cd "$root"
-    PATH="$root/bin:$PATH" \
-      GH_ARGS_FILE="$root/gh.args" \
-      BREW_ARGS_FILE="$root/brew.args" \
-      GH_FILES=$'Casks/target.rb\n' \
-      BREW_MUTATE_OUTSIDE=1 \
-      bash "$script" devantler-tech/homebrew-tap 42 "$root/output"
-  ) >/dev/null 2>&1; then
+  base="$(cd "$root" && git rev-parse HEAD)"
+  commit_target_change "$root"
+  head="$(cd "$root" && git rev-parse HEAD)"
+  if BREW_MUTATE_OUTSIDE=1 run_helper "$root" "$base" "$head" >/dev/null 2>&1; then
     echo "FAIL: autocorrection was allowed to dirty an unrelated Cask"
     fail=1
   else
@@ -154,17 +171,12 @@ assert_out_of_scope_mutation_is_fatal() {
 }
 
 assert_untracked_scope_escape_is_fatal() {
-  local root
+  local root base head
   root="$(new_fixture untracked-escape)"
-  if (
-    cd "$root"
-    PATH="$root/bin:$PATH" \
-      GH_ARGS_FILE="$root/gh.args" \
-      BREW_ARGS_FILE="$root/brew.args" \
-      GH_FILES=$'Casks/target.rb\n' \
-      BREW_CREATE_UNTRACKED=1 \
-      bash "$script" devantler-tech/homebrew-tap 42 "$root/output"
-  ) >/dev/null 2>&1; then
+  base="$(cd "$root" && git rev-parse HEAD)"
+  commit_target_change "$root"
+  head="$(cd "$root" && git rev-parse HEAD)"
+  if BREW_CREATE_UNTRACKED=1 run_helper "$root" "$base" "$head" >/dev/null 2>&1; then
     echo "FAIL: an untracked sibling Cask bypassed the post-fix allowlist"
     fail=1
   else
@@ -173,21 +185,17 @@ assert_untracked_scope_escape_is_fatal() {
 }
 
 assert_staged_start_is_fatal() {
-  local root
+  local root base head
   root="$(new_fixture staged-start)"
+  base="$(cd "$root" && git rev-parse HEAD)"
+  commit_target_change "$root"
+  head="$(cd "$root" && git rev-parse HEAD)"
   (
     cd "$root"
     printf 'staged-scope-escape\n' >>Casks/sibling.rb
     git add Casks/sibling.rb
   )
-  if (
-    cd "$root"
-    PATH="$root/bin:$PATH" \
-      GH_ARGS_FILE="$root/gh.args" \
-      BREW_ARGS_FILE="$root/brew.args" \
-      GH_FILES=$'Casks/target.rb\n' \
-      bash "$script" devantler-tech/homebrew-tap 42 "$root/output"
-  ) >/dev/null 2>&1; then
+  if run_helper "$root" "$base" "$head" >/dev/null 2>&1; then
     echo "FAIL: a staged sibling Cask bypassed the clean-start guard"
     fail=1
   elif [ -e "$root/brew.args" ]; then
@@ -199,18 +207,23 @@ assert_staged_start_is_fatal() {
 }
 
 assert_no_cask_is_noop() {
-  local root dirty
+  local root base head dirty
   root="$(new_fixture no-cask)"
+  base="$(cd "$root" && git rev-parse HEAD)"
   (
     cd "$root"
-    PATH="$root/bin:$PATH" \
-      GH_ARGS_FILE="$root/gh.args" \
-      BREW_ARGS_FILE="$root/brew.args" \
-      GH_FILES=$'README.md\n' \
-      bash "$script" devantler-tech/homebrew-tap 42 "$root/output"
+    printf 'docs-only\n' >>README.md
+    git add README.md
+    git commit -qm docs-only
   )
+  head="$(cd "$root" && git rev-parse HEAD)"
+  if ! run_helper "$root" "$base" "$head"; then
+    echo "FAIL: a PR without Cask changes was rejected"
+    fail=1
+    return
+  fi
   dirty="$(sed -n 's/^dirty=//p' "$root/output")"
-  if [ "$dirty" != false ] || [ -e "$root/brew.args" ]; then
+  if [ "$dirty" != false ] || [ -e "$root/brew.args" ] || [ -s "$root/targets" ]; then
     echo "FAIL: a PR without Cask changes was not a clean no-op"
     fail=1
   else
@@ -219,38 +232,50 @@ assert_no_cask_is_noop() {
 }
 
 assert_workflow_contract() {
-  local workflow fix_block
+  local workflow style_block
   workflow="$here/../.github/workflows/ci.yaml"
-  fix_block="$(sed -n '/- name: 🎨 brew style --fix/,/- name: 📤 Commit/p' "$workflow")"
+  style_block="$(sed -n '/- name: 📥 Checkout (same-repo PR/,/- name: 🎨 brew style (gate)/p' "$workflow")"
 
   # Literal GitHub/shell expressions are the workflow contract, not values for this test to expand.
   # shellcheck disable=SC2016
-  if ! grep -Fq 'pull-requests: read' "$workflow"; then
-    echo "FAIL: style job cannot read the authoritative PR file list"
+  if ! grep -Fq 'fetch-depth: 0' <<<"$style_block"; then
+    echo "FAIL: pushable PR checkout does not fetch immutable base/head history"
     fail=1
-  elif ! grep -Fq 'GH_TOKEN: ${{ github.token }}' <<<"$fix_block"; then
-    echo "FAIL: PR-scoped autocorrection does not use the read-only workflow token"
+  elif ! grep -Fq 'ref: ${{ github.event.pull_request.head.sha }}' <<<"$style_block"; then
+    echo "FAIL: pushable PR checkout still follows a mutable branch name"
     fail=1
-  elif ! grep -Fq 'if [ "$EVENT_NAME" = "pull_request" ] && [ "$HEAD_REPO" = "$GITHUB_REPOSITORY" ]; then' <<<"$fix_block"; then
-    echo "FAIL: same-repository PR autocorrection is not explicitly gated"
+  elif ! grep -Fq 'BASE_SHA: ${{ github.event.pull_request.base.sha }}' <<<"$style_block" \
+    || ! grep -Fq 'EXPECTED_HEAD: ${{ github.event.pull_request.head.sha }}' <<<"$style_block"; then
+    echo "FAIL: workflow does not bind discovery and push to the event base/head"
     fail=1
-  elif ! grep -Fq 'bash scripts/autocorrect-pr-casks.sh "$GITHUB_REPOSITORY" "$PR_NUMBER" "$GITHUB_OUTPUT"' <<<"$fix_block"; then
-    echo "FAIL: the workflow does not delegate same-repository fixes to the scoped helper"
+  elif ! grep -Fq 'bash scripts/autocorrect-pr-casks.sh "$BASE_SHA" "$EXPECTED_HEAD" "$GITHUB_OUTPUT" "$TARGET_MANIFEST"' <<<"$style_block"; then
+    echo "FAIL: workflow does not delegate immutable discovery to the scoped helper"
     fail=1
-  elif ! grep -Fq 'brew style --fix ./Casks/ || true' <<<"$fix_block"; then
+  elif grep -Fq 'git-auto-commit-action' <<<"$style_block" \
+    || grep -Fq 'file_pattern: "Casks/*.rb"' <<<"$style_block"; then
+    echo "FAIL: broad third-party Cask staging remains in the pushable path"
+    fail=1
+  elif ! grep -Fq 'git add -- "$target"' <<<"$style_block"; then
+    echo "FAIL: commit step does not stage exact manifest targets"
+    fail=1
+  elif ! grep -Fq 'git push --force-with-lease="refs/heads/$HEAD_REF:$EXPECTED_HEAD" origin "HEAD:refs/heads/$HEAD_REF"' <<<"$style_block"; then
+    echo "FAIL: autocorrect push is not an exact-event-head compare-and-swap"
+    fail=1
+  elif ! grep -Fq 'brew style --fix ./Casks/ || true' <<<"$style_block"; then
     echo "FAIL: the check-only fallback no longer evaluates the complete Cask tree"
     fail=1
   elif ! grep -Fq 'for test_script in test/*.test.sh; do' "$workflow"; then
     echo "FAIL: CI does not execute every hermetic script regression test"
     fail=1
   else
-    echo "ok: workflow scopes pushable PR fixes and retains the full-tree check-only gate"
+    echo "ok: workflow binds immutable discovery, exact staging, and leased push"
   fi
 }
 
 assert_pr_scoped_fix
-assert_api_failure_is_fatal
-assert_unsafe_path_is_fatal
+assert_missing_history_is_fatal
+assert_checked_out_head_mismatch_is_fatal
+assert_newline_path_is_fatal
 assert_out_of_scope_mutation_is_fatal
 assert_untracked_scope_escape_is_fatal
 assert_staged_start_is_fatal

--- a/test/autocorrect-pr-casks.test.sh
+++ b/test/autocorrect-pr-casks.test.sh
@@ -39,6 +39,9 @@ done
 if [ "${BREW_MUTATE_OUTSIDE:-0}" = 1 ]; then
   printf 'wrong-scope\n' >>Casks/sibling.rb
 fi
+if [ "${BREW_CREATE_UNTRACKED:-0}" = 1 ]; then
+  printf 'untracked-scope-escape\n' >Casks/untracked.rb
+fi
 exit "${BREW_EXIT:-0}"
 STUB
   chmod +x "$root/bin/gh" "$root/bin/brew"
@@ -150,6 +153,51 @@ assert_out_of_scope_mutation_is_fatal() {
   fi
 }
 
+assert_untracked_scope_escape_is_fatal() {
+  local root
+  root="$(new_fixture untracked-escape)"
+  if (
+    cd "$root"
+    PATH="$root/bin:$PATH" \
+      GH_ARGS_FILE="$root/gh.args" \
+      BREW_ARGS_FILE="$root/brew.args" \
+      GH_FILES=$'Casks/target.rb\n' \
+      BREW_CREATE_UNTRACKED=1 \
+      bash "$script" devantler-tech/homebrew-tap 42 "$root/output"
+  ) >/dev/null 2>&1; then
+    echo "FAIL: an untracked sibling Cask bypassed the post-fix allowlist"
+    fail=1
+  else
+    echo "ok: scope guard rejects an untracked sibling created by autocorrection"
+  fi
+}
+
+assert_staged_start_is_fatal() {
+  local root
+  root="$(new_fixture staged-start)"
+  (
+    cd "$root"
+    printf 'staged-scope-escape\n' >>Casks/sibling.rb
+    git add Casks/sibling.rb
+  )
+  if (
+    cd "$root"
+    PATH="$root/bin:$PATH" \
+      GH_ARGS_FILE="$root/gh.args" \
+      BREW_ARGS_FILE="$root/brew.args" \
+      GH_FILES=$'Casks/target.rb\n' \
+      bash "$script" devantler-tech/homebrew-tap 42 "$root/output"
+  ) >/dev/null 2>&1; then
+    echo "FAIL: a staged sibling Cask bypassed the clean-start guard"
+    fail=1
+  elif [ -e "$root/brew.args" ]; then
+    echo "FAIL: brew ran despite a staged sibling Cask at startup"
+    fail=1
+  else
+    echo "ok: staged Cask state fails closed before autocorrection"
+  fi
+}
+
 assert_no_cask_is_noop() {
   local root dirty
   root="$(new_fixture no-cask)"
@@ -204,6 +252,8 @@ assert_pr_scoped_fix
 assert_api_failure_is_fatal
 assert_unsafe_path_is_fatal
 assert_out_of_scope_mutation_is_fatal
+assert_untracked_scope_escape_is_fatal
+assert_staged_start_is_fatal
 assert_no_cask_is_noop
 assert_workflow_contract
 


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Why

KSail `v7.175.2` published all artifacts, but its final Homebrew handoff failed because tap PR #1218 was widened from `Casks/ksail-desktop.rb` to include `Casks/ksail.rb`. The tap's style job ran `brew style --fix ./Casks/` and committed every dirty Cask, while KSail's one-Cask validator correctly refused the expanded scope.

## What changed

- check out the event's exact head with full history and derive non-deleted Cask paths from the immutable three-dot base/head diff using NUL-delimited filenames;
- autocorrect only those explicit paths on pushable same-repository PRs;
- reject unsafe/missing paths, unavailable history, head mismatches, dirty starts, and any out-of-scope post-fix mutation before staging;
- stage only the helper's exact post-guard target manifest and push with a lease pinned to the event head, so a branch reset or concurrent push rejects the autocorrection;
- retain the complete-tree check-only path for forks and merge groups and the complete-tree final style gate;
- run every hermetic shell regression test in CI;
- apply the exact automation-generated `ksail.rb` style blob already present on #1218, without changing its version, URLs, or digests, so #1218 contracts back to the intended desktop-only diff once this lands.

## Validation

- `bash test/autocorrect-pr-casks.test.sh`
- `bash test/is-superseded.test.sh`
- `shellcheck scripts/*.sh test/*.test.sh`
- `actionlint .github/workflows/ci.yaml`
- `git diff --check`
- `ruby -c Casks/ksail.rb`
- exact local `Casks/ksail.rb` blob matched the current #1218 branch blob (`3e79546a22614869d81aa0ab64ecf076f6476e79`)

The new regression includes an adversarial `brew` stub that fixes the requested Cask and also dirties a sibling; the scope guard must reject that run. It also proves missing-history failure, exact checkout/head binding, NUL-safe rejection of a newline-bearing Git filename, staged and untracked escapes, a no-Cask no-op, exact manifest staging, and the SHA-pinned push lease.

Fixes #1220
